### PR TITLE
Fixing definition for MPI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ A new feature of the CMake build system is GooFit Packages, which are complete p
 * Examples have a script that run all of them with timing info
 * Travis builds [PR 32](https://github.com/GooFit/GooFit/pull/32)
 * Improved documentation, automatically builds on changes to master
+* `GooFit::Application`, based on [CLI11](https://github.com/henryiii/CLI11). See [PR](https://github.com/GooFit/GooFit/pull/36) and [Issue](https://github.com/GooFit/GooFit/issues/33).
 * Added (this) changelog
 
 The Makefile system is somewhere between deprecated and obsolete, and will be removed in the next release. It is not possible to do an in-source CMake build while the makefile system is in place, so please use a build directory.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,7 +96,8 @@ if(GOOFIT_MPI)
     find_package(MPI REQUIRED)
 
     # Added globally
-    add_definitions("${MPI_CXX_COMPILE_FLAGS} -DGOOFIT_MPI")
+    add_definitions("-DGOOFIT_MPI")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${MPI_CXX_COMPILE_FLAGS}")
     include_directories(${MPI_CXX_INCLUDE_PATH})
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${MPI_CXX_LINK_FLAGS}")
     link_libraries(${MPI_CXX_LIBRARIES})


### PR DESCRIPTION
This is an attempt to fix one of the review points for the GooFit Application merge. This *should* correctly set the definition when compiling.