### PR TITLE
Root fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,8 +36,8 @@ endif()
 
 
 ### Options ###
-set(DEVICE_LISTING CUDA OMP TBB CPP Auto)
-set(HOST_LISTING OMP TBB CPP)
+set(DEVICE_LISTING CUDA OMP CPP Auto)
+set(HOST_LISTING OMP CPP)
 mark_as_advanced(DEVICE_LISTING HOST_LISTING)
 
 set(GOOFIT_DEVICE Auto CACHE STRING "The compute device, options are ${DEVICE_LISTING}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,10 +156,7 @@ endif()
 # The target is setup to avoid clashes with fakeroot
 # Include directories are not picked up by FindCUDA
 find_package(ROOT 6 REQUIRED COMPONENTS Minuit)
-add_library(Root INTERFACE)
 include_directories(BEFORE "include/goofit/rootstuff")
-include_directories(AFTER SYSTEM "${ROOT_INCLUDE_DIRS}")
-target_link_libraries(Root INTERFACE ${ROOT_LIBRARIES})
 # Note: it is very important that the includes and links for root are after fakeroot!
  
 
@@ -253,7 +250,7 @@ include_directories(${PROJECT_SOURCE_DIR}/include)
 include_directories(${PROJECT_SOURCE_DIR}/MCBooster)
 
 add_library(goofit_lib INTERFACE)
-target_link_libraries(goofit_lib INTERFACE goofit_base PDFs rootstuff Root)
+target_link_libraries(goofit_lib INTERFACE goofit_base PDFs rootstuff ROOT::ROOT)
 
 option(GOOFIT_EXAMPLES "Build the example programs" ON)
 if(GOOFIT_EXAMPLES)

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ GooFit using OpenMP.
 
 ## Requirements
 
-* A new version of CMake if using the CMake build. At least 3.5, the newer the better. CMake is incredibly easy to install.
+* A new version of CMake if using the CMake build. At least 3.5, tested with 3.7. CMake is incredibly easy to install.
  * With CMake, thrust is downloaded automatically for OpenMP if not found
  * GoogleTest is downloaded automatically
 * A ROOT 6 build highly recommended.

--- a/README.md
+++ b/README.md
@@ -13,8 +13,10 @@ GooFit using OpenMP.
 
 ## Requirements
 
-* A new version of CMake if using the CMake build. At least 3.4, but 3.7 is better.
-* A ROOT 6 build highly recommended
+* A new version of CMake if using the CMake build. At least 3.5, the newer the better. CMake is incredibly easy to install.
+ * With CMake, thrust is downloaded automatically for OpenMP if not found
+ * GoogleTest is downloaded automatically
+* A ROOT 6 build highly recommended.
 * If using CUDA:
  * CUDA 7.5 and 8.0 tested, older versions should work for now
  * An nVidia GPU supporting compute capability at least 2.0 (3.5 recommended)
@@ -46,7 +48,7 @@ If you want to change compiler, set `CC` and `CXX` to appropriate defaults *befo
 cmake .. -DGOOFIT_DEVICE=CUDA -DGOOFIT_HOST=OMP
 ```
 
-Valid options are `CUDA` (device only), `OMP`, `CPP`, and `TBB` (unavailable currently).
+Valid options are `CUDA` (device only), `OMP`, and CPP (host only). While the current backend is used, `CPP`, and `TBB` will probably remain unavailable for device calculations. The default is `Auto`, and will select `CUDA` if CUDA is found.
 
 Other custom options supported along with the defaults:
 

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ GooFit using OpenMP.
 
 ## Requirements
 
-* A new version of CMake if using the CMake build. At least 3.5, tested with 3.7. CMake is incredibly easy to install.
- * With CMake, thrust is downloaded automatically for OpenMP if not found
+* A new version of CMake if using the CMake build. Like ROOT, the minimum is 3.4, but tested primarily with 3.7. CMake is incredibly easy to install.
+ * With CMake, Thrust is downloaded automatically for OpenMP if not found
  * GoogleTest is downloaded automatically
 * A ROOT 6 build highly recommended.
 * If using CUDA:
@@ -26,7 +26,8 @@ GooFit using OpenMP.
 ## Getting the files
 
 * Clone with git:
-```
+
+```bash
 git clone git://github.com/goofit/goofit.git
 cd goofit
 ```
@@ -36,12 +37,25 @@ You can either checkout a tagged version, or stay on the master for the latest a
 ## Building 
 
 The build system now uses CMake. The procedure is standard for CMake builds:
-```
+
+```bash
 mkdir build
 cd build
 cmake ..
 make
 ```
+
+> If you don't have a modern CMake, you can get a local copy on linux using:
+>
+> ```bash
+> mkdir cmake && wget -qO- "https://cmake.org/files/v3.7/cmake-3.7.2-Linux-x86_64.tar.gz" | tar --strip-components=1 -xz -C cmake
+> ```
+>
+> Now, just use the local copy instead:
+>
+> ```bash
+> ./cmake/bin/cmake ..
+> ```
 
 If you want to change compiler, set `CC` and `CXX` to appropriate defaults *before* you run cmake either inline or in your environment. If you want to set the host and device backends, you can set those options. The defaults are:
 ```
@@ -117,7 +131,7 @@ If you are building with separable compilation, you can also use `goofit_add_pdf
 
 > If you want to extend the Makefile system instead, copy a Makefile from a different directory, changing the relevent project name (only one program per directory supported), and make a new target in `examples/Makefile`. 
 
-To add packages, use standard CMake tools. For example, to add [Boost](https://cmake.org/cmake/help/v3.7/module/FindBoost.html) 1.49+ filesystem and `TTreeReader` from ROOT:
+To add packages, use standard CMake tools. For example (CMake 3.5), to add [Boost](https://cmake.org/cmake/help/v3.7/module/FindBoost.html) 1.49+ filesystem and `TTreeReader` from ROOT:
 
 ```cmake
 set(Boost_USE_STATIC_LIBS OFF)

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ GooFit using OpenMP.
 
 ## Requirements
 
+* A new version of CMake if using the CMake build. At least 3.4, but 3.7 is better.
+* A ROOT 6 build highly recommended
 * If using CUDA:
  * CUDA 7.5 and 8.0 tested, older versions should work for now
  * An nVidia GPU supporting compute capability at least 2.0 (3.5 recommended)
@@ -102,7 +104,7 @@ If you want to run an individual example, those are in subdirectories in example
 
 The examples are designed to be easy to add to. Make a new directory, then add a new CMakeLists.txt in your directory with one or more of the following two lines:
 
-```
+```cmake
 goofit_add_directory()
 goofit_add_executible(MyNewExample MyNewExample.cu)
 ```
@@ -112,6 +114,19 @@ The first line adds your `.cu` file with goofit code as an executible, and the s
 If you are building with separable compilation, you can also use `goofit_add_pdf(mypdf.cu)` to add a PDF. This will also require that you include any directory that you need with `include_directory`, as usual.
 
 > If you want to extend the Makefile system instead, copy a Makefile from a different directory, changing the relevent project name (only one program per directory supported), and make a new target in `examples/Makefile`. 
+
+To add packages, use standard CMake tools. For example, to add [Boost](https://cmake.org/cmake/help/v3.7/module/FindBoost.html) 1.49+ filesystem and `TTreeReader` from ROOT:
+
+```cmake
+set(Boost_USE_STATIC_LIBS OFF)
+set(Boost_USE_MULTITHREADED ON)
+set(Boost_USE_STATIC_RUNTIME OFF)
+find_package(Boost 1.49 REQUIRED COMPONENTS filesystem)
+
+goofit_add_executable(K3Pi K3Pi.cu)
+target_link_libraries(MyNewExample Boost::filesystem ROOT::TreePlayer)
+
+```
 
 ## Adding a new project
   

--- a/cmake/FindROOT.cmake
+++ b/cmake/FindROOT.cmake
@@ -9,6 +9,10 @@
 # ROOT_LIBRARY_DIR    PATH to the library directory
 # ROOT_DEFINITIONS    Compiler definitions and flags
 #
+# The modern CMake 3 imported targets are also created:
+# ROOT::ROOT (Most common libraries)
+# ROOT::<name> (The library with name)
+#
 # Updated by K. Smith (ksmith37@nd.edu) to properly handle
 #  dependencies in ROOT_GENERATE_DICTIONARY
 
@@ -43,30 +47,45 @@ if(ROOT_CONFIG_EXECUTABLE)
         RELATIVE "${ROOT_LIBRARY_DIR}"
         "${ROOT_LIBRARY_DIR}/${CMAKE_SHARED_LIBRARY_PREFIX}*${CMAKE_SHARED_LIBRARY_SUFFIX}")
 
-    set(all_rootlibs "")
+    set(ROOT_ALLLIBS "")
     foreach(_file ${ROOT_LIBFILELIST})
         string(REGEX REPLACE "^${CMAKE_SHARED_LIBRARY_PREFIX}" "" _newer ${_file})
         string(REGEX REPLACE "${CMAKE_SHARED_LIBRARY_SUFFIX}$" "" _newest ${_newer})
-        list(APPEND ROOT_LIBNAMELIST ${_newest})
+        list(APPEND ROOT_ALLLIBS ${_newest})
     endforeach()
 
+    set(ROOT_CORELIBS Core RIO Net Hist Graf Graf3d Gpad Tree Rint Postscript Matrix Physics MathCore Thread MultiProc)
 
-    set(core_rootlibs                 Core RIO Net Hist Graf Graf3d Gpad Tree Rint Postscript Matrix Physics MathCore Thread MultiProc)
+    add_library(ROOT::ROOT INTERFACE IMPORTED)
 
     set(ROOT_LIBRARIES)
-    foreach(_cpt ${all_rootlibs} ${ROOT_FIND_COMPONENTS})
+    foreach(_cpt ${ROOT_ALLLIBS})
       find_library(ROOT_${_cpt}_LIBRARY ${_cpt} HINTS ${ROOT_LIBRARY_DIR})
       if(ROOT_${_cpt}_LIBRARY)
         mark_as_advanced(ROOT_${_cpt}_LIBRARY)
+        add_library(ROOT::${_cpt} SHARED IMPORTED)
+        set_target_properties(ROOT::${_cpt} PROPERTIES
+            INTERFACE_INCLUDE_DIRECTORIES "${ROOT_INCLUDE_DIRS}")
+        set_target_properties(ROOT::${_cpt} PROPERTIES
+                    IMPORTED_LINK_INTERFACE_LANGUAGES "CXX"
+                    IMPORTED_LOCATION "${ROOT_${_cpt}_LIBRARY}")
       endif()
     endforeach()
 
-    foreach(_cpt ${core_rootlibs} ${ROOT_FIND_COMPONENTS})
+    set(targetlist)
+    foreach(_cpt ${ROOT_CORELIBS} ${ROOT_FIND_COMPONENTS})
       if(ROOT_${_cpt}_LIBRARY)
         list(APPEND ROOT_LIBRARIES "${ROOT_${_cpt}_LIBRARY}")
         list(REMOVE_ITEM ROOT_FIND_COMPONENTS ${_cpt})
+        list(APPEND targetlist ROOT::${_cpt})
       endif()
     endforeach()
+
+    set_target_properties(ROOT::ROOT PROPERTIES
+        INTERFACE_INCLUDE_DIRECTORIES "${ROOT_INCLUDE_DIRS}")
+    set_target_properties(ROOT::ROOT PROPERTIES
+        INTERFACE_LINK_LIBRARIES "${targetlist}")
+    unset(targetlist)
 
     list(REMOVE_DUPLICATES ROOT_LIBRARIES)
 

--- a/cmake/FindROOT.cmake
+++ b/cmake/FindROOT.cmake
@@ -38,8 +38,20 @@ if(ROOT_CONFIG_EXECUTABLE)
         OUTPUT_STRIP_TRAILING_WHITESPACE)
     set(ROOT_LIBRARY_DIRS ${ROOT_LIBRARY_DIR})
 
+    file(GLOB ROOT_LIBFILELIST
+        LIST_DIRECTORIES false
+        RELATIVE "${ROOT_LIBRARY_DIR}"
+        "${ROOT_LIBRARY_DIR}/${CMAKE_SHARED_LIBRARY_PREFIX}*${CMAKE_SHARED_LIBRARY_SUFFIX}")
+
+    set(all_rootlibs "")
+    foreach(_file ${ROOT_LIBFILELIST})
+        string(REGEX REPLACE "^${CMAKE_SHARED_LIBRARY_PREFIX}" "" _newer ${_file})
+        string(REGEX REPLACE "${CMAKE_SHARED_LIBRARY_SUFFIX}$" "" _newest ${_newer})
+        list(APPEND ROOT_LIBNAMELIST ${_newest})
+    endforeach()
+
+
     set(core_rootlibs                 Core RIO Net Hist Graf Graf3d Gpad Tree Rint Postscript Matrix Physics MathCore Thread MultiProc)
-    set(all_rootlibs ${core_rootlibs} RooFit RooFitCore Minuit Minuit2 TreePlayer Proof Cling Geom RooStats TMVA MathMore)
 
     set(ROOT_LIBRARIES)
     foreach(_cpt ${all_rootlibs} ${ROOT_FIND_COMPONENTS})


### PR DESCRIPTION
This updates the FindROOT module to support arbitrary root libraries instead of having to add them as needed. It searches your library directory to generate both classic and new style targets.

This adds the new style targets, as well, so you can link to ROOT::ROOT (or ROOT::component) to handle everything for you (such as include directories). ~~This might bump the min required version of CMake to 3.5, since that is when FindBOOST added the new targets, but I think it probably does work on 3.4. I've left the version as 3.4 in the README.~~ Correction: it works just fine on CMake 3.4. Testing a new version of CMake is just two extra lines in your build directory:

```bash
wget https://cmake.org/files/v3.4/cmake-3.4.0-Linux-x86_64.sh
bash cmake-3.4.0-Linux-x86_64.sh
# Answer yes to both questions
./cmake-3.4.0-Linux-x86_64/bin/cmake ..
```

Please review.