### PR TITLE
OMP fixes for standalone GooFit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+*.swp
+*~
 *.so
 .project
 compile_commands.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,9 @@ A new feature of the CMake build system is GooFit Packages, which are complete p
 * CMake build system: See [Issue 22](https://github.com/GooFit/GooFit/issues/22) and [PR 23](https://github.com/GooFit/GooFit/pull/23).
   * Auto compute capability detection
   * Auto Cuda/OMP selection 
-  * Added CPP single threaded backend, support for MacOS
-  * Optional separable compilation for PDFs, automatic for non-CUDA builds
-  * (Almost) supports Intel compilers
+  * Added CPP single threaded backend, support for MacOS and IDEs/debuggers
+  * Separable compilation for PDFs
+  * Support for more compilers, such as Clang and Intel
   * Macros for `CMakeLists.txt` for adding a new package in 2-3 lines
   * Auto linking for build directory
   * Auto download of dependencies through git submodules and CMake
@@ -26,8 +26,9 @@ A new feature of the CMake build system is GooFit Packages, which are complete p
 * Improved documentation, automatically builds on changes to master
 * `GooFit::Application`, based on [CLI11](https://github.com/CLIUtils/CLI11). See [PR](https://github.com/GooFit/GooFit/pull/36) and [Issue](https://github.com/GooFit/GooFit/issues/33).
 * Better naming to match CUDA [PR 61](https://github.com/GooFit/GooFit/pull/61)
-* Better Variable based caching with multi-pdf support [PR 65](/GooFit/GooFit/pull/65)
+* Better Variable based caching with multi-pdf support [PR 65](https://github.com/GooFit/GooFit/pull/65) and [PR 68](https://github.com/GooFit/GooFit/pull/68)
 * Logging and formatting support, cleanup of old commented code [PR 66](/GooFit/GooFit/pull/66)
+* Support for Minuit2 (default and availabe without ROOT) joins Minuit1
 * Added MPI support in [PR 51](https://github.com/GooFit/GooFit/pull/51)
 * Added PyGooFit: preliminary Python bindings using [PyBind11](http://pybind11.readthedocs.io/en/master/)
 * Added (this) changelog

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -173,10 +173,10 @@ set(GOOFIT_ARCH Auto CACHE STRING "The GPU Archetecture, can be Auto, All, Commo
 
 option(GOOFIT_MPI "Turn on MPI for goofit" OFF)
 
+
 if(GOOFIT_MPI)
     find_package(MPI REQUIRED)
 
-    # Added globally
     add_definitions("-DGOOFIT_MPI")
     add_compile_options(${MPI_CXX_COMPILE_FLAGS})
     include_directories(${MPI_CXX_INCLUDE_PATH})
@@ -215,20 +215,21 @@ set(THRUST_INCLUDE_DIR "${PROJECT_SOURCE_DIR}/extern/thrust")
 find_package(Thrust 1.8 REQUIRED)
 include_directories(SYSTEM "${THRUST_INCLUDE_DIRS}")
 
+# This library provides an interface to openMP, etc for all libraries.
+add_library(goofit_mt INTERFACE)
+
 if(GOOFIT_DEVICE STREQUAL OMP OR GOOFIT_HOST STREQUAL OMP OR GOOFIT_DEVICE STREQUAL TBB OR GOOFIT_HOST STREQUAL TBB)
     find_package(OpenMP REQUIRED)
-    add_compile_options(${OpenMP_CXX_FLAGS})
+    target_compile_options(goofit_mt INTERFACE ${OpenMP_CXX_FLAGS})
     find_package(Threads REQUIRED)
-    link_libraries(Threads::Threads)
-    link_libraries(${OpenMP_CXX_FLAGS})
+    target_link_libraries(goofit_mt INTERFACE Threads::Threads)
+    target_link_libraries(goofit_mt INTERFACE ${OpenMP_CXX_FLAGS})
 endif()
 
 if(GOOFIT_DEVICE STREQUAL TBB OR GOOFIT_HOST STREQUAL TBB)
     find_package(TBB COMPONENTS tbbmalloc tbbmalloc_proxy tbb_preview)
-    #set(CMAKE_CXX_FLAGS -xMIC-AVX512)
-    #set(CMAKE_CXX_FLAGS "-xHOST -qopenmp")
-    include_directories(SYSTEM "${TBB_INCLUDE_DIRS}")
-    link_libraries(${TBB_LIBRARIES})
+    target_include_directories(goofit_mt INTERFACE SYSTEM "${TBB_INCLUDE_DIRS}")
+    target_link_libraries(goofit_mt INTERFACE ${TBB_LIBRARIES})
 endif()
 
 # Include directories are not picked up by FindCUDA
@@ -267,7 +268,7 @@ function(goofit_add_library GNAME)
         add_sanitizers(${GNAME})
         target_compile_options(${GNAME} PUBLIC -x c++)
     endif()
-    target_link_libraries(${GNAME} rang CLI11 fmt)
+    target_link_libraries(${GNAME} rang CLI11 fmt goofit_mt)
 
     if(ROOT_FOUND)
         target_link_libraries(${GNAME} ROOT::ROOT)

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ doing maximum-likelihood fits with a familiar syntax.
 * If using CPP:
   * Single threaded builds are available for debugging and development (such as on the default Clang on macOS)
 
+A list of installs for different common platforms is available [here](./docs/SYSTEM_INSTALL.md).
+
 ## Getting the files
 
 * Clone with git:

--- a/docs/CONVERTING20.md
+++ b/docs/CONVERTING20.md
@@ -39,14 +39,14 @@ The new `GooFit::Application`, which is not required but provides GooFit options
 #include "goofit/Application.h"
 
 // Place this at the beginning of main
-GooFit::Application app{"Optional discription", argv, argc};
+GooFit::Application app{"Optional discription", argc, argv};
 
 // Command line options can be added here.
 
 try {
     app.run();
 } catch(const GooFit::ParseError &e) {
-    app.exit(e);
+    return app.exit(e);
 }
 ```
 
@@ -73,3 +73,8 @@ istream >> var; // Shortcut
 ```
 
 The other values do not provide shortcut access. Copying a variable is explicitly disallowed; it was possible before but gave incorrect results.
+
+## Namespaces
+
+GooFit no longer leaks the `std::` namespace, and some of GooFit is now inside the GooFit namespace. To be future-proof, you can add `using namespace GooFit;` at the top of your code.
+

--- a/docs/SYSTEM_INSTALL.md
+++ b/docs/SYSTEM_INSTALL.md
@@ -1,0 +1,44 @@
+# Installing GooFit on different systems
+
+The docker command for each system is listed at the beginning of each command, to show setup from scratch. Ignore that line if you are not using docker.
+
+## CentOS 7
+
+docker run -it centos
+yum install epel-release -y
+yum install cmake3 git -y
+yum group install -y "Development Tools"
+git clone --recursive https://github.com/GooFit/GooFit.git
+cd GooFit
+mkdir build
+cd build
+cmake3 ..
+make
+
+
+## Alpine Linux 3.5
+
+A truly minimal system, Alpine gives you a working Docker system under 5 MB. To get a minimal install of GooFit:
+
+```bash
+docker run -it alpine sh
+apk add --no-cache make cmake g++ git libexecinfo-dev
+git clone --recursive https://github.com/GooFit/GooFit.git
+cd GooFit
+mkdir build
+cd build
+cmake ..
+make
+```
+
+## Ubuntu 17.04
+
+docker run -it ubuntu
+apt-get update && apt-get install 
+git clone --recursive https://github.com/GooFit/GooFit.git
+cd GooFit
+mkdir build
+cd build
+cmake ..
+make
+

--- a/docs/SYSTEM_INSTALL.md
+++ b/docs/SYSTEM_INSTALL.md
@@ -2,8 +2,13 @@
 
 The docker command for each system is listed at the beginning of each command, to show setup from scratch. Ignore that line if you are not using docker.
 
+The following commands show you how to get a *minimal* install of GooFit on a vanilla system; you will probably want to add ROOT for your system, and possibly CUDA if you have a graphics card. If you do not have ROOT, some functionality, such as the Minuit1 version of the fitter, will not be available, and most of the examples will not be included in the build.
+
 ## CentOS 7
 
+For simplicity, this uses the EPEL version of CMake; feel free to download CMake directly from Kitware instead. The EPEL version has the odd `cmake3` name to distinguish it from CentOS default.
+
+```bash
 docker run -it centos
 yum install epel-release -y
 yum install cmake3 git -y
@@ -14,7 +19,8 @@ mkdir build
 cd build
 cmake3 ..
 make
-
+make test
+```
 
 ## Alpine Linux 3.5
 
@@ -29,16 +35,21 @@ mkdir build
 cd build
 cmake ..
 make
+make test
 ```
 
 ## Ubuntu 17.04
 
+Ubiquitous Ubuntu works also. Ubuntu was used for the NVidia docker solution due to better support from NVidia. 
+
+```bash
 docker run -it ubuntu
-apt-get update && apt-get install 
+apt-get update && apt-get install -y git cmake make g++
 git clone --recursive https://github.com/GooFit/GooFit.git
 cd GooFit
 mkdir build
 cd build
 cmake ..
 make
-
+make test
+```

--- a/docs/SYSTEM_INSTALL.md
+++ b/docs/SYSTEM_INSTALL.md
@@ -1,6 +1,6 @@
 # Installing GooFit on different systems
 
-The docker command for each system is listed at the beginning of each command, to show setup from scratch. Ignore that line if you are not using docker.
+The Docker command for each system is listed at the beginning of each command, to show setup from scratch. Ignore that line if you are not using Docker.
 
 The following commands show you how to get a *minimal* install of GooFit on a vanilla system; you will probably want to add ROOT for your system, and possibly CUDA if you have a graphics card. If you do not have ROOT, some functionality, such as the Minuit1 version of the fitter, will not be available, and most of the examples will not be included in the build.
 

--- a/docs/SYSTEM_INSTALL.md
+++ b/docs/SYSTEM_INSTALL.md
@@ -24,7 +24,7 @@ make test
 
 ## Alpine Linux 3.5
 
-A truly minimal system, Alpine gives you a working Docker system under 5 MB. To get a minimal install of GooFit:
+A truly minimal system, Alpine gives you a working Docker system under 3 MB.
 
 ```bash
 docker run -it alpine sh
@@ -38,18 +38,18 @@ make
 make test
 ```
 
-## Ubuntu 17.04
+## Ubuntu 16.04
 
-Ubiquitous Ubuntu works also. Ubuntu was used for the NVidia docker solution due to better support from NVidia. 
+Ubiquitous Ubuntu works also. Ubuntu was used for the NVidia docker solution due to better support from NVidia. The following example uses ninja-build instead of make.
 
 ```bash
 docker run -it ubuntu
-apt-get update && apt-get install -y git cmake make g++
+apt-get update && apt-get install -y git cmake ninja-build g++
 git clone --recursive https://github.com/GooFit/GooFit.git
 cd GooFit
 mkdir build
 cd build
 cmake ..
-make
-make test
+cmake --build .
+ctest
 ```


### PR DESCRIPTION
This corrects the OpenMP build flags for the stand alone Minuit 2; the OpenMP flags were leaking from GooFit into Minuit2. GooFit now runs out-of-the box in CentOS and Alpine Docker. Better docs for building.