### PR TITLE
Backtrace

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,27 +1,27 @@
 [submodule "cmake"]
 	path = cmake
-	url = ../../CLIUtils/cmake
+	url = ../../CLIUtils/cmake.git
 [submodule "extern/generics"]
 	path = extern/generics
 	url = ../generics.git
 [submodule "extern/CLI11"]
 	path = extern/CLI11
-	url = ../../CLIUtils/CLI11
+	url = ../../CLIUtils/CLI11.git
 [submodule "extern/Minuit2"]
 	path = extern/Minuit2
-	url = ../Minuit2
+	url = ../Minuit2.git
 [submodule "extern/thrust"]
 	path = extern/thrust
-	url = ../../thrust/thrust
+	url = ../../thrust/thrust.git
 [submodule "extern/googletest"]
 	path = extern/googletest
-	url = ../../google/googletest
+	url = ../../google/googletest.git
 [submodule "extern/rang"]
 	path = extern/rang
-	url = ../../agauniyal/rang
+	url = ../../agauniyal/rang.git
 [submodule "extern/pybind11"]
 	path = extern/pybind11
-	url = ../../pybind/pybind11
+	url = ../../pybind/pybind11.git
 [submodule "extern/FeatureDetector"]
 	path = extern/FeatureDetector
 	url = ../FeatureDetector.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -161,13 +161,20 @@ if(GOOFIT_TRACE)
     add_definitions("-DGOOFIT_TRACE_FLAG=1")
 endif()
 
+# Adding backtrace (optional)
 # Some systems need execinfo explicitly linked
 # Standard CMake module
 find_package(Backtrace)
+add_library(backtrace INTERFACE)
 if(Backtrace_FOUND)
-    # Assuming no extra flags, assuming execinfo.h header
-    link_libraries(${Backtrace_LIBRARIES})
+    # Assuming no extra flags
+    target_include_directories(backtrace INTERFACE ${Backtrace_INCLUDE_DIR})
+    target_link_libraries(backtrace INTERFACE ${Backtrace_LIBRARIES})
 endif()
+configure_file(
+    "${PROJECT_SOURCE_DIR}/include/goofit/detail/Backtrace.h.in"
+    "${PROJECT_BINARY_DIR}/include/goofit/detail/Backtrace.h"
+)
 
 set(GOOFIT_ARCH Auto CACHE STRING "The GPU Archetecture, can be Auto, All, Common, a number, or a name")
 

--- a/include/goofit/PdfBase.h
+++ b/include/goofit/PdfBase.h
@@ -3,6 +3,8 @@
 #include "goofit/GlobalCudaDefines.h"
 
 #include "goofit/Variable.h"
+#include "goofit/detail/Abort.h"
+
 #include <set>
 #include <map>
 #include <vector>
@@ -131,5 +133,4 @@ private:
     __host__ void setIndices();
 };
 
-void abortWithCudaPrintFlush(std::string file, int line, std::string reason, const PdfBase* pdf = 0);
 

--- a/include/goofit/detail/Abort.h
+++ b/include/goofit/detail/Abort.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <string>
+
+class PdfBase;
+
+namespace GooFit {
+
+/// Smart abort that includes the file name and location, and prints a stack trace if possible
+void abort(std::string file, int line, std::string reason, const PdfBase* pdf = nullptr);
+
+}
+
+/// Classic abort name
+[[deprecated("Use GooFit::abort instead")]]
+inline void abortWithCudaPrintFlush(std::string file, int line, std::string reason, const PdfBase* pdf = nullptr) {
+    GooFit::abort(file, line, reason, pdf);
+}

--- a/include/goofit/detail/Backtrace.h.in
+++ b/include/goofit/detail/Backtrace.h.in
@@ -1,0 +1,6 @@
+#pragma once
+
+#cmakedefine01 Backtrace_FOUND
+#if Backtrace_FOUND
+# include <${Backtrace_HEADER}>
+#endif

--- a/scripts/ModernizeGooFit.py
+++ b/scripts/ModernizeGooFit.py
@@ -100,10 +100,11 @@ conversion = [
     (r'\bCONST_PI\b', 'M_PI'),
     (r'normalise', 'normalize'),
     (r'Normalise', 'Normalize'),
-    (r'\bPdfBase::parCont\b', 'std::vector<Variable*>')
-    (r'\bPdfBase::obsCont\b', 'std::vector<Variable*>')
-    (r'\bobsCont\b', 'std::vector<Variable*>')
-    (r'\bparCont\b', 'std::vector<Variable*>')
+    (r'\bPdfBase::parCont\b', 'std::vector<Variable*>'),
+    (r'\bPdfBase::obsCont\b', 'std::vector<Variable*>'),
+    (r'\bobsCont\b', 'std::vector<Variable*>'),
+    (r'\bparCont\b', 'std::vector<Variable*>'),
+    (r'\babortWithCudaPrintFlush\b', 'GooFit::abort'),
 ]
 
 def fix_text(contents):

--- a/src/PDFs/DP4Pdf.cu
+++ b/src/PDFs/DP4Pdf.cu
@@ -423,7 +423,7 @@ __host__ fptype DPPdf::normalize() const {
     }
 
     if(std::isnan(ret))
-        abortWithCudaPrintFlush(__FILE__, __LINE__, getName() + " NAN normalization in DPPdf", this);
+        GooFit::abort(__FILE__, __LINE__, getName() + " NAN normalization in DPPdf", this);
     
     host_normalisation[parameters] = 1.0/ret;
     // printf("end of normalize %f\n", ret);

--- a/src/PDFs/GooPdf.cu
+++ b/src/PDFs/GooPdf.cu
@@ -221,7 +221,7 @@ __host__ double GooPdf::sumOfNll(int numVars) const {
     thrust::constant_iterator<fptype*> arrayAddress(dev_event_array);
     double dummy = 0;
 
-    //if (host_callnumber >= 2) abortWithCudaPrintFlush(__FILE__, __LINE__, getName() + " debug abort", this);
+    //if (host_callnumber >= 2) GooFit::abort(__FILE__, __LINE__, getName() + " debug abort", this);
     thrust::counting_iterator<int> eventIndex(0);
 
     double ret;
@@ -276,7 +276,7 @@ __host__ double GooPdf::calculateNLL() const {
     //}
 
     if(host_normalisation[parameters] <= 0)
-        abortWithCudaPrintFlush(__FILE__, __LINE__, getName() + " non-positive normalisation", this);
+        GooFit::abort(__FILE__, __LINE__, getName() + " non-positive normalisation", this);
 
     MEMCPY_TO_SYMBOL(normalisationFactors, host_normalisation, totalParams*sizeof(fptype), 0, cudaMemcpyHostToDevice);
     cudaDeviceSynchronize(); // Ensure normalisation integrals are finished
@@ -291,12 +291,12 @@ __host__ double GooPdf::calculateNLL() const {
     fptype ret = sumOfNll(numVars);
 
     if(0 == ret)
-        abortWithCudaPrintFlush(__FILE__, __LINE__, getName() + " zero NLL", this);
+        GooFit::abort(__FILE__, __LINE__, getName() + " zero NLL", this);
 
     //if (cpuDebug & 1) std::cout << "Full NLL " << host_callnumber << " : " << 2*ret << std::endl;
     //setDebugMask(0);
 
-    //if ((cpuDebug & 1) && (host_callnumber >= 1)) abortWithCudaPrintFlush(__FILE__, __LINE__, getName() + " debug abort", this);
+    //if ((cpuDebug & 1) && (host_callnumber >= 1)) GooFit::abort(__FILE__, __LINE__, getName() + " debug abort", this);
     return 2*ret;
 }
 
@@ -468,16 +468,16 @@ __host__ fptype GooPdf::normalize() const {
 #endif
 
     if(std::isnan(sum)) {
-        abortWithCudaPrintFlush(__FILE__, __LINE__, getName() + " NaN in normalisation", this);
+        GooFit::abort(__FILE__, __LINE__, getName() + " NaN in normalisation", this);
     } else if(0 >= sum) {
-        abortWithCudaPrintFlush(__FILE__, __LINE__, "Non-positive normalisation", this);
+        GooFit::abort(__FILE__, __LINE__, "Non-positive normalisation", this);
     }
 
     ret *= sum;
 
 
     if(0 == ret)
-        abortWithCudaPrintFlush(__FILE__, __LINE__, "Zero integral");
+        GooFit::abort(__FILE__, __LINE__, "Zero integral");
 
     GOOFIT_TRACE("{}: Param {} integral is ~= {}", getName(), parameters, ret);
     host_normalisation[parameters] = 1.0/ret;

--- a/src/PDFs/PdfBase.cu
+++ b/src/PDFs/PdfBase.cu
@@ -22,7 +22,7 @@ __host__ void PdfBase::copyParams(const std::vector<double>& pars) const {
 
         if(std::isnan(host_params[i])) {
             std::cout << " agh, parameter is NaN, die " << i << std::endl;
-            abortWithCudaPrintFlush(__FILE__, __LINE__, "NaN in parameter");
+            GooFit::abort(__FILE__, __LINE__, "NaN in parameter");
         }
     }
 

--- a/src/goofit/Abort.cc
+++ b/src/goofit/Abort.cc
@@ -1,0 +1,47 @@
+#include "goofit/detail/Abort.h"
+#include "goofit/PdfBase.h"
+#include "goofit/Error.h"
+#include "goofit/Color.h"
+#include "goofit/detail/Backtrace.h"
+
+namespace GooFit {
+
+void abort(std::string file, int line, std::string reason, const PdfBase* pdf) {
+    void* stackarray[20];
+    
+    std::cout << GooFit::reset << GooFit::red << "Abort called from " << file << " line " << line << " due to " << reason << std::endl;
+    
+    if(pdf) {
+        std::vector<Variable*> pars = pdf->getParameters();
+        std::cout << "Parameters of " << pdf->getName() << " : \n";
+        
+        for(Variable* v : pars) {
+            if(0 > v->getIndex())
+                continue;
+            
+            std::cout << "  " << v->getName() << " (" << v->getIndex() << ") :\t" << host_params[v->getIndex()] << std::endl;
+        }
+    }
+    
+    std::cout << "Parameters (" << totalParams << ") :\n";
+    
+    for(int i = 0; i < totalParams; ++i) {
+        std::cout << host_params[i] << " ";
+    }
+    
+    
+    
+#if Backtrace_FOUND
+    std::cout << GooFit::bold << std::endl;
+    // get void* pointers for all entries on the stack
+    size_t size = backtrace(stackarray, 20);
+    // print out all the frames to stderr
+    backtrace_symbols_fd(stackarray, size, 2);
+#endif
+
+    std::cout << GooFit::reset << std::flush;
+    
+    throw GooFit::GeneralError(reason);
+}
+
+}

--- a/src/goofit/CMakeLists.txt
+++ b/src/goofit/CMakeLists.txt
@@ -47,6 +47,9 @@ goofit_add_library(FunctorWriter
 
 goofit_add_library(PdfBase
     PdfBase.cc
+    Abort.cc
+    ${PROJECT_SOURCE_DIR}/include/goofit/detail/Abort.h
+    ${PROJECT_BINARY_DIR}/include/goofit/detail/Backtrace.h
     ${PROJECT_SOURCE_DIR}/include/goofit/Error.h
     ${PROJECT_SOURCE_DIR}/include/goofit/PdfBase.h
     ${PROJECT_SOURCE_DIR}/include/goofit/FitControl.h
@@ -55,6 +58,8 @@ goofit_add_library(PdfBase
     ${PROJECT_SOURCE_DIR}/include/goofit/Log.h
     ${PROJECT_SOURCE_DIR}/include/goofit/GlobalCudaDefines.h
     )
+
+target_link_libraries(PdfBase backtrace)
 
 
 # Note: order is important on Linux, derived classes first

--- a/src/goofit/PdfBase.cc
+++ b/src/goofit/PdfBase.cc
@@ -7,7 +7,6 @@
 
 #include <algorithm>
 #include <set>
-#include <execinfo.h>
 
 #include "goofit/FitManager.h"
 #include "goofit/BinnedDataSet.h"
@@ -185,39 +184,4 @@ __host__ ROOT::Minuit2::FunctionMinimum PdfBase::fitTo(DataSet *data) {
     setData(data);
     FitManager fitter{this};
     return fitter.fit();
-}
-
-void abortWithCudaPrintFlush(std::string file, int line, std::string reason, const PdfBase* pdf) {
-    void* stackarray[20];
-    
-    std::cout << GooFit::reset << GooFit::red << "Abort called from " << file << " line " << line << " due to " << reason << std::endl;
-    
-    if(pdf) {
-        std::vector<Variable*> pars = pdf->getParameters();
-        std::cout << "Parameters of " << pdf->getName() << " : \n";
-        
-        for(Variable* v : pars) {
-            if(0 > v->getIndex())
-                continue;
-            
-            std::cout << "  " << v->getName() << " (" << v->getIndex() << ") :\t" << host_params[v->getIndex()] << std::endl;
-        }
-    }
-    
-    std::cout << "Parameters (" << totalParams << ") :\n";
-    
-    for(int i = 0; i < totalParams; ++i) {
-        std::cout << host_params[i] << " ";
-    }
-    
-    std::cout << GooFit::bold << std::endl;
-    
-    
-    // get void* pointers for all entries on the stack
-    size_t size = backtrace(stackarray, 20);
-    // print out all the frames to stderr
-    backtrace_symbols_fd(stackarray, size, 2);
-    std::cout << GooFit::reset << std::flush;
-    
-    throw GooFit::GeneralError(reason);
 }


### PR DESCRIPTION
This allows builds without Backtrace, and correctly uses whatever the system provides. This has reworked the `abortWithCudaPrintFlush` function into `GooFit::abort`. The old one still is available, but emits a compiler warning when used.