### PR TITLE
Adding GooFit namespace everywhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,8 @@ try {
 
 See [CLI11] for more details. The [pipipi0](./examples/pipipi0DPFit) example has an example of a complex set of options.
 
+The other key differences in code are the addition of the `GooFit` namespace (`using namespace GooFit` allows fast conversion), and the removal of direct access to members of `Variable` (using getters/setters, or directly treat the variable like its value).
+
 See [Converting to GooFit 2.0](./docs/CONVERTING20.md) and the [Changelog](./CHANGELOG.md).
 
 ## Improving Performance with MPI

--- a/docs/CONVERTING20.md
+++ b/docs/CONVERTING20.md
@@ -76,5 +76,5 @@ The other values do not provide shortcut access. Copying a variable is explicitl
 
 ## Namespaces
 
-GooFit no longer leaks the `std::` namespace, and some of GooFit is now inside the GooFit namespace. To be future-proof, you can add `using namespace GooFit;` at the top of your code.
+GooFit no longer leaks the `std::` namespace, and all of GooFit is now inside the GooFit namespace. You can add `using namespace GooFit;` at the top of your code.
 

--- a/examples/2d_plot/2d_plot.cu
+++ b/examples/2d_plot/2d_plot.cu
@@ -16,6 +16,7 @@
 #include <random>
 
 using namespace std;
+using namespace GooFit;
 
 int main(int argc, char** argv) {
 

--- a/examples/DP4/DP4.cu
+++ b/examples/DP4/DP4.cu
@@ -8,7 +8,9 @@
 #include "goofit/PDFs/AddPdf.h"
 #include "goofit/UnbinnedDataSet.h"
 #include "goofit/PDFs/DP4Pdf.h"
+
 using namespace std;
+using namespace GooFit;
 
 const fptype _mD0 = 1.8645;
 const fptype piPlusMass = 0.13957018;

--- a/examples/SigGen/SigGen.cu
+++ b/examples/SigGen/SigGen.cu
@@ -13,6 +13,7 @@
 #include <thrust/count.h>
 
 using namespace std;
+using namespace GooFit;
 
 // Constants used in more than one PDF component.
 const fptype _mD0 = 1.8645;

--- a/examples/TDDP4/TDDP4.cu
+++ b/examples/TDDP4/TDDP4.cu
@@ -15,6 +15,7 @@
 #include <fstream>
 
 using namespace std;
+using namespace GooFit;
 
 // Constants used in more than one PDF component.
 const fptype _mD0 = 1.8645;

--- a/examples/addition/addition.cu
+++ b/examples/addition/addition.cu
@@ -17,6 +17,7 @@
 #include <iostream>
 
 using namespace std;
+using namespace GooFit;
 
 int main(int argc, char** argv) {
     GooFit::Application app("Addition example", argc, argv);

--- a/examples/chisquare/chisquare.cu
+++ b/examples/chisquare/chisquare.cu
@@ -23,6 +23,7 @@ timeval startTime, stopTime, totalTime;
 #include <string>
 
 using namespace std;
+using namespace GooFit;
 
 Variable* decayTime = 0;
 Variable* constaCoef = 0;

--- a/examples/convolution/convolution.cu
+++ b/examples/convolution/convolution.cu
@@ -9,6 +9,7 @@
 #include "TRandom.h"
 
 using namespace std;
+using namespace GooFit;
 
 double cpu_bw(double x, double x0, double gamma) {
     double ret = gamma;

--- a/examples/dalitz/dalitz.cu
+++ b/examples/dalitz/dalitz.cu
@@ -29,6 +29,7 @@
 #include "goofit/UnbinnedDataSet.h"
 
 using namespace std;
+using namespace GooFit;
 
 TCanvas* foo;
 TCanvas* foodal;

--- a/examples/exponential/exponential.cu
+++ b/examples/exponential/exponential.cu
@@ -6,8 +6,6 @@
 #include <CLI/Timer.hpp>
 #include <iostream>
 
-using namespace std;
-
 int main(int argc, char** argv) {
     GooFit::Application app("Exponential example", argc, argv);
 
@@ -18,10 +16,10 @@ int main(int argc, char** argv) {
     }
 
     // Independent variable.
-    Variable xvar{"xvar", 0, log(1 + RAND_MAX/2)};
+    GooFit::Variable xvar{"xvar", 0, log(1 + RAND_MAX/2)};
 
     // Data set
-    UnbinnedDataSet data(&xvar);
+    GooFit::UnbinnedDataSet data(&xvar);
 
     // Generate toy events.
     
@@ -36,12 +34,12 @@ int main(int argc, char** argv) {
     std::cout << GooFit::magenta << gen_timer << GooFit::reset << std::endl;
 
     // Fit parameter
-    Variable alpha{"alpha", -2, 0.1, -10, 10};
+    GooFit::Variable alpha{"alpha", -2, 0.1, -10, 10};
     // GooPdf object
-    ExpPdf exppdf{"exppdf", &xvar, &alpha};
+    GooFit::ExpPdf exppdf{"exppdf", &xvar, &alpha};
     exppdf.setData(&data);
 
-    FitManager fitter{&exppdf};
+    GooFit::FitManager fitter{&exppdf};
     fitter.fit();
     
     if(alpha.getValue() < -1.01 || alpha.getValue() > -0.99)

--- a/examples/exponential/exponential1.cu
+++ b/examples/exponential/exponential1.cu
@@ -6,6 +6,7 @@
 #include <iostream>
 
 using namespace std;
+using namespace GooFit;
 
 int main(int argc, char** argv) {
     GooFit::Application app("Exponential example", argc, argv);

--- a/examples/exponential/exponential2.cu
+++ b/examples/exponential/exponential2.cu
@@ -13,6 +13,7 @@
 #include <iostream>
 
 using namespace std;
+using namespace GooFit;
 
 int main(int argc, char** argv) {
     GooFit::Application app("Exponential example", argc, argv);

--- a/examples/pipipi0DPFit/pipipi0DPFit.cu
+++ b/examples/pipipi0DPFit/pipipi0DPFit.cu
@@ -50,6 +50,7 @@
 #include "goofit/FunctorWriter.h"
 
 using namespace std;
+using namespace GooFit;
 
 TCanvas* foo;
 TCanvas* foodal;

--- a/examples/product/product.cu
+++ b/examples/product/product.cu
@@ -6,6 +6,7 @@
 #include "goofit/PDFs/ProdPdf.h"
 
 using namespace std;
+using namespace GooFit;
 
 int main(int argc, char** argv) {
 

--- a/examples/simpleFit/simpleFit.cu
+++ b/examples/simpleFit/simpleFit.cu
@@ -16,6 +16,7 @@
 #include <iostream>
 
 using namespace std;
+using namespace GooFit;
 
 // CPU-side Novosibirsk evaluation for use in generating toy MC.
 double novosib(double x, double peak, double width, double tail) {

--- a/examples/zachFit/zachFit.cu
+++ b/examples/zachFit/zachFit.cu
@@ -27,6 +27,7 @@
 #include <fmt/format.h>
 
 using namespace fmt::literals;
+using namespace GooFit;
 
 TH1D* getMCData(DataSet *data, Variable* var, std::string filename) {
     TH1D* mchist = new TH1D{"mc_hist", "", 300, 0.1365, 0.1665};

--- a/include/goofit/Application.h
+++ b/include/goofit/Application.h
@@ -33,7 +33,15 @@ void signal_handler(int s){
     std::exit(1); // will call the correct exit func, no unwinding of the stack though
 }
    
-using namespace CLI;
+// Importing into the GooFit namespace the main classes from CLI11
+using CLI::ParseError;
+using CLI::FileError;
+using CLI::App;
+using CLI::Option;
+using CLI::ExistingFile;
+using CLI::ExistingDirectory;
+using CLI::NonexistentPath;
+using CLI::ExitCodes;
 
 class Application : public CLI::App {
 protected:

--- a/include/goofit/BinnedDataSet.h
+++ b/include/goofit/BinnedDataSet.h
@@ -5,6 +5,9 @@
 #include <map>
 #include <vector>
 
+namespace GooFit {
+
+
 class BinnedDataSet : public DataSet {
     // Class for rectangularly binned datasets - every bin the same size.
 
@@ -55,4 +58,6 @@ private:
     std::vector<fptype> binerrors;
 
 };
+
+} // namespace GooFit
 

--- a/include/goofit/DataSet.h
+++ b/include/goofit/DataSet.h
@@ -10,6 +10,9 @@
 #include "goofit/Variable.h"
 #include "goofit/Error.h"
 
+namespace GooFit {
+
+
 class DataSet {
 public:
     DataSet(Variable* var, std::string n = "");
@@ -70,4 +73,6 @@ private:
 protected:
     std::vector<Variable*> variables;
 };
+
+} // namespace GooFit
 

--- a/include/goofit/Faddeeva.h
+++ b/include/goofit/Faddeeva.h
@@ -2,5 +2,10 @@
 
 #include "goofit/GlobalCudaDefines.h"
 
+namespace GooFit {
+
+
 fptype cpuvoigtian(fptype x, fptype m, fptype w, fptype s);
+
+} // namespace GooFit
 

--- a/include/goofit/FitControl.h
+++ b/include/goofit/FitControl.h
@@ -6,6 +6,9 @@
 #include <vector>
 #include <string>
 
+namespace GooFit {
+
+
 class PdfBase;
 
 class FitControl {
@@ -65,4 +68,6 @@ class BinnedChisqFit : public FitControl {
 public:
     BinnedChisqFit() : FitControl(true, "ptr_to_Chisq") {}
 };
+
+} // namespace GooFit
 

--- a/include/goofit/FitManager.h
+++ b/include/goofit/FitManager.h
@@ -4,5 +4,10 @@
 
 #include "goofit/fitting/FitManagerMinuit2.h"
 
+namespace GooFit {
+
+
 typedef GooFit::FitManagerMinuit2 FitManager;
+
+} // namespace GooFit
 

--- a/include/goofit/FunctorWriter.h
+++ b/include/goofit/FunctorWriter.h
@@ -4,6 +4,9 @@
 
 #include "goofit/GlobalCudaDefines.h" // Need this for 'fptype' 
 
+namespace GooFit {
+
+
 class PdfBase;
 
 void writeToFile(PdfBase* pdf, const char* fname);
@@ -11,4 +14,6 @@ void readFromFile(PdfBase* pdf, const char* fname);
 
 void writeListOfNumbers(thrust::host_vector<fptype>& target, const char* fname);
 void readListOfNumbers(thrust::host_vector<fptype>& target, const char* fname);
+
+} // namespace GooFit
 

--- a/include/goofit/GlobalCudaDefines.h
+++ b/include/goofit/GlobalCudaDefines.h
@@ -6,7 +6,9 @@
 #include <cmath>
 #include <string>
 
+namespace GooFit {
 extern int host_callnumber;
+}
 
 //  Non-cuda defines
 #if THRUST_DEVICE_SYSTEM!=THRUST_DEVICE_SYSTEM_CUDA
@@ -57,6 +59,7 @@ enum gooError {gooSuccess = 0, gooErrorMemoryAllocation};
 
 // For CUDA case, just use existing errors, renamed
 #include <driver_types.h>      // Needed for cudaError_t
+
 enum gooError {gooSuccess = cudaSuccess,
                gooErrorMemoryAllocation = cudaErrorMemoryAllocation
               };
@@ -68,9 +71,10 @@ enum gooError {gooSuccess = cudaSuccess,
 #define BLOCKDIM (1)
 #endif
 
+namespace GooFit {
 gooError gooMalloc(void** target, size_t bytes);
 gooError gooFree(void* ptr);
-
+}
 #ifndef GOOFIT_SINGLES
 
 typedef double fptype;
@@ -100,3 +104,4 @@ T rsqrt(T val) {return 1.0/sqrt(val);}
 template<typename T>
 T pow(T x, int y) {return pow(x, (T) y);}
 #endif
+

--- a/include/goofit/GlobalCudaDefines.h
+++ b/include/goofit/GlobalCudaDefines.h
@@ -74,7 +74,7 @@ enum gooError {gooSuccess = cudaSuccess,
 namespace GooFit {
 gooError gooMalloc(void** target, size_t bytes);
 gooError gooFree(void* ptr);
-}
+
 #ifndef GOOFIT_SINGLES
 
 typedef double fptype;
@@ -89,6 +89,7 @@ typedef float fptype;
 
 #endif
 
+}
 
 // Often faster than pow, and works with ints on CUDA<8
 #define POW2(x) ((x)*(x))

--- a/include/goofit/Log.h
+++ b/include/goofit/Log.h
@@ -5,6 +5,9 @@
 
 #include <iostream>
 
+namespace GooFit {
+
+
 #define GOOFIT_INFO(...)  {std::cout << GooFit::reset << GooFit::blue; fmt::print(__VA_ARGS__); std::cout << GooFit::reset << std::endl;}
 #define GOOFIT_INFO_C(color, ...) {std::cout << GooFit::reset << color; fmt::print(__VA_ARGS__); std::cout << GooFit::reset << std::endl;}
 #define GOOFIT_STATUS(...)  {std::cout << GooFit::reset << GooFit::magenta; fmt::print(__VA_ARGS__); std::cout << GooFit::reset << std::endl;}
@@ -35,4 +38,6 @@
 #define GOOFIT_TRACE(...)
 #define GOOFIT_TRACEF(...)
 #endif
+
+} // namespace GooFit
 

--- a/include/goofit/PDFs/AddPdf.h
+++ b/include/goofit/PDFs/AddPdf.h
@@ -2,6 +2,9 @@
 
 #include "goofit/PDFs/GooPdf.h"
 
+namespace GooFit {
+
+
 class AddPdf : public GooPdf {
 public:
 
@@ -18,4 +21,6 @@ protected:
 private:
     bool extended;
 };
+
+} // namespace GooFit
 

--- a/include/goofit/PDFs/ArgusPdf.h
+++ b/include/goofit/PDFs/ArgusPdf.h
@@ -2,6 +2,9 @@
 
 #include "goofit/PDFs/GooPdf.h"
 
+namespace GooFit {
+
+
 class ArgusPdf : public GooPdf {
 public:
     ArgusPdf(std::string n, Variable* _x, Variable* m, Variable* s, bool upper, Variable* power = nullptr);
@@ -13,4 +16,6 @@ public:
 private:
 
 };
+
+} // namespace GooFit
 

--- a/include/goofit/PDFs/BWPdf.h
+++ b/include/goofit/PDFs/BWPdf.h
@@ -2,6 +2,9 @@
 
 #include "goofit/PDFs/GooPdf.h"
 
+namespace GooFit {
+
+
 class BWPdf : public GooPdf {
 
 public:
@@ -9,3 +12,5 @@ public:
 private:
 
 };
+} // namespace GooFit
+

--- a/include/goofit/PDFs/BifurGaussPdf.h
+++ b/include/goofit/PDFs/BifurGaussPdf.h
@@ -2,6 +2,9 @@
 
 #include "goofit/PDFs/GooPdf.h"
 
+namespace GooFit {
+
+
 class BifurGaussPdf : public GooPdf {
 public:
     BifurGaussPdf(std::string n, Variable* _x, Variable* m, Variable* sL, Variable* sR);
@@ -11,4 +14,6 @@ public:
 private:
 
 };
+
+} // namespace GooFit
 

--- a/include/goofit/PDFs/BinTransformPdf.h
+++ b/include/goofit/PDFs/BinTransformPdf.h
@@ -2,6 +2,9 @@
 
 #include "goofit/PDFs/GooPdf.h"
 
+namespace GooFit {
+
+
 // Transforms ND coordinates into a single bin number.
 class BinTransformPdf : public GooPdf {
 public:
@@ -14,3 +17,5 @@ public:
 private:
 
 };
+} // namespace GooFit
+

--- a/include/goofit/PDFs/CompositePdf.h
+++ b/include/goofit/PDFs/CompositePdf.h
@@ -2,6 +2,9 @@
 
 #include "goofit/PDFs/GooPdf.h"
 
+namespace GooFit {
+
+
 // Composites of arbitrary functions, ie f(x) = h(g(x))
 // for any h and g. In principle we should allow multi-
 // dimensional compositing, eg f(x, y) = i(g(x, y), h(x, y)).
@@ -15,3 +18,5 @@ public:
 private:
 
 };
+} // namespace GooFit
+

--- a/include/goofit/PDFs/ConvolutionPdf.h
+++ b/include/goofit/PDFs/ConvolutionPdf.h
@@ -3,6 +3,9 @@
 #include "goofit/PDFs/GooPdf.h"
 #include <thrust/device_vector.h>
 
+namespace GooFit {
+
+
 class ConvolutionPdf : public GooPdf {
 public:
 
@@ -23,4 +26,6 @@ private:
     int workSpaceIndex;
 
 };
+
+} // namespace GooFit
 

--- a/include/goofit/PDFs/CorrGaussianPdf.h
+++ b/include/goofit/PDFs/CorrGaussianPdf.h
@@ -2,6 +2,9 @@
 
 #include "goofit/PDFs/GooPdf.h"
 
+namespace GooFit {
+
+
 class CorrGaussianPdf : public GooPdf {
 public:
     CorrGaussianPdf(std::string n, Variable* _x, Variable* _y, Variable* mean1, Variable* sigma1, Variable* mean2,
@@ -11,4 +14,6 @@ public:
 private:
 
 };
+
+} // namespace GooFit
 

--- a/include/goofit/PDFs/CrystalBallPdf.h
+++ b/include/goofit/PDFs/CrystalBallPdf.h
@@ -2,6 +2,9 @@
 
 #include "goofit/PDFs/GooPdf.h"
 
+namespace GooFit {
+
+
 class CrystalBallPdf : public GooPdf {
 public:
     CrystalBallPdf(std::string n, Variable* _x, Variable* m, Variable* s, Variable* a, Variable* power = nullptr);
@@ -12,3 +15,5 @@ public:
 private:
 
 };
+} // namespace GooFit
+

--- a/include/goofit/PDFs/DP4Pdf.h
+++ b/include/goofit/PDFs/DP4Pdf.h
@@ -15,6 +15,9 @@ See *.cu file for more details
 #include <tuple>
 #include <thrust/remove.h>
 
+namespace GooFit {
+
+
 
 #ifdef SEPARABLE
 extern __constant__ unsigned int AmpIndices[500];
@@ -168,4 +171,6 @@ private:
 };
 
 
+
+} // namespace GooFit
 

--- a/include/goofit/PDFs/DalitzPlotHelpers.h
+++ b/include/goofit/PDFs/DalitzPlotHelpers.h
@@ -15,6 +15,9 @@ See *.cu file for more details
 #include <thrust/iterator/constant_iterator.h>
 #include <thrust/device_vector.h>
 
+namespace GooFit {
+
+
 template<typename E>
 constexpr typename std::underlying_type<E>::type enum_to_underlying(E e) {
     return static_cast<typename std::underlying_type<E>::type>(e);
@@ -109,4 +112,6 @@ protected:
     Iterator last;
     difference_type stride;
 };
+
+} // namespace GooFit
 

--- a/include/goofit/PDFs/DalitzPlotPdf.h
+++ b/include/goofit/PDFs/DalitzPlotPdf.h
@@ -5,6 +5,9 @@
 
 #include <thrust/complex.h>
 
+namespace GooFit {
+
+
 class SpecialResonanceIntegrator;
 class SpecialResonanceCalculator;
 
@@ -68,4 +71,6 @@ private:
     unsigned int resonance_i;
     unsigned int parameters;
 };
+
+} // namespace GooFit
 

--- a/include/goofit/PDFs/DalitzVetoPdf.h
+++ b/include/goofit/PDFs/DalitzVetoPdf.h
@@ -3,6 +3,9 @@
 #include "goofit/PDFs/GooPdf.h"
 #include "goofit/PDFs/TddpPdf.h"
 
+namespace GooFit {
+
+
 struct VetoInfo {
     DaughterPair cyclic_index;
     Variable* minimum;
@@ -17,3 +20,5 @@ public:
 private:
 
 };
+} // namespace GooFit
+

--- a/include/goofit/PDFs/EvalVar.h
+++ b/include/goofit/PDFs/EvalVar.h
@@ -14,6 +14,9 @@ See *.cu file for more details
 #include <mcbooster/GContainers.h>
 #include <mcbooster/GFunctional.h>
 
+namespace GooFit {
+
+
 
 struct Dim5: public mcbooster::IFunctionArray {
     Dim5() {
@@ -115,4 +118,6 @@ struct Dim5: public mcbooster::IFunctionArray {
         variables[4] = phi(pM, ppip, ppim, pK, ppip2);
     }
 };
+
+} // namespace GooFit
 

--- a/include/goofit/PDFs/EventWeightedAddPdf.h
+++ b/include/goofit/PDFs/EventWeightedAddPdf.h
@@ -2,6 +2,9 @@
 
 #include "goofit/PDFs/GooPdf.h"
 
+namespace GooFit {
+
+
 // This class is just like AddPdf except that the
 // event weights are properties of each event, not variables
 // in the fit.
@@ -19,3 +22,5 @@ protected:
 private:
 
 };
+} // namespace GooFit
+

--- a/include/goofit/PDFs/ExpGausPdf.h
+++ b/include/goofit/PDFs/ExpGausPdf.h
@@ -2,6 +2,9 @@
 
 #include "goofit/PDFs/GooPdf.h"
 
+namespace GooFit {
+
+
 class ExpGausPdf : public GooPdf {
 public:
     ExpGausPdf(std::string n, Variable* _x, Variable* m, Variable* s, Variable* t);
@@ -9,3 +12,5 @@ public:
 private:
 
 };
+} // namespace GooFit
+

--- a/include/goofit/PDFs/ExpPdf.h
+++ b/include/goofit/PDFs/ExpPdf.h
@@ -2,6 +2,9 @@
 
 #include "goofit/PDFs/GooPdf.h"
 
+namespace GooFit {
+
+
 class ExpPdf : public GooPdf {
 public:
     ExpPdf(std::string n, Variable* _x, Variable* alpha, Variable* offset = nullptr);
@@ -16,3 +19,5 @@ public:
 private:
 
 };
+} // namespace GooFit
+

--- a/include/goofit/PDFs/GaussianPdf.h
+++ b/include/goofit/PDFs/GaussianPdf.h
@@ -2,6 +2,9 @@
 
 #include "goofit/PDFs/GooPdf.h"
 
+namespace GooFit {
+
+
 class GaussianPdf : public GooPdf {
 public:
     GaussianPdf(std::string n, Variable* _x, Variable* m, Variable* s);
@@ -15,3 +18,5 @@ public:
 private:
 
 };
+} // namespace GooFit
+

--- a/include/goofit/PDFs/GooPdf.h
+++ b/include/goofit/PDFs/GooPdf.h
@@ -6,6 +6,13 @@
 #include "goofit/UnbinnedDataSet.h"
 #include "goofit/PDFs/MetricTaker.h"
 
+#ifdef ROOT_FOUND
+class TH1D;
+#endif
+
+namespace GooFit {
+
+
 // TODO: Replace this with class MetricTaker;
 // And fill in the .cu files where needed
 
@@ -28,9 +35,6 @@ extern unsigned int num_device_functions;
 extern std::map<void*, int> functionAddressToDeviceIndexMap;
 #endif
 
-#ifdef ROOT_FOUND
-class TH1D;
-#endif
 
 __device__ int dev_powi(int base, int exp);  // Implemented in SmoothHistogramPdf.
 void* getMetricPointer(std::string name);
@@ -100,4 +104,6 @@ private:
 
 };
 
+
+} // namespace GooFit
 

--- a/include/goofit/PDFs/IncoherentSumPdf.h
+++ b/include/goofit/PDFs/IncoherentSumPdf.h
@@ -4,6 +4,9 @@
 #include "goofit/PDFs/TddpPdf.h"
 #include <thrust/complex.h>
 
+namespace GooFit {
+
+
 // Very similar class to TddpPdf, but without time dependence
 // (so no time resolution or mixing) and ignoring interference between
 // waves. This makes the code just different enough, the assumptions are
@@ -75,4 +78,6 @@ private:
     unsigned int parameters;
 };
 
+
+} // namespace GooFit
 

--- a/include/goofit/PDFs/InterHistPdf.h
+++ b/include/goofit/PDFs/InterHistPdf.h
@@ -4,6 +4,9 @@
 #include "goofit/BinnedDataSet.h"
 #include <thrust/device_vector.h>
 
+namespace GooFit {
+
+
 class InterHistPdf : public GooPdf {
 public:
     InterHistPdf(std::string n,
@@ -18,4 +21,6 @@ private:
     fptype* host_constants;
     int numVars;
 };
+
+} // namespace GooFit
 

--- a/include/goofit/PDFs/JohnsonSUPdf.h
+++ b/include/goofit/PDFs/JohnsonSUPdf.h
@@ -2,6 +2,9 @@
 
 #include "goofit/PDFs/GooPdf.h"
 
+namespace GooFit {
+
+
 class JohnsonSUPdf : public GooPdf {
 public:
     JohnsonSUPdf(std::string n, Variable* _x, Variable* m, Variable* s, Variable* g, Variable* d);
@@ -15,3 +18,5 @@ public:
 private:
 
 };
+} // namespace GooFit
+

--- a/include/goofit/PDFs/KinLimitBWPdf.h
+++ b/include/goofit/PDFs/KinLimitBWPdf.h
@@ -2,6 +2,9 @@
 
 #include "goofit/PDFs/GooPdf.h"
 
+namespace GooFit {
+
+
 class KinLimitBWPdf : public GooPdf {
 
 public:
@@ -14,3 +17,5 @@ public:
 private:
 
 };
+} // namespace GooFit
+

--- a/include/goofit/PDFs/LandauPdf.h
+++ b/include/goofit/PDFs/LandauPdf.h
@@ -2,6 +2,9 @@
 
 #include "goofit/PDFs/GooPdf.h"
 
+namespace GooFit {
+
+
 class LandauPdf : public GooPdf {
 public:
     LandauPdf(std::string n, Variable* _x, Variable* mpv, Variable* sigma);
@@ -9,3 +12,5 @@ public:
 private:
 
 };
+} // namespace GooFit
+

--- a/include/goofit/PDFs/LineshapesPdf.h
+++ b/include/goofit/PDFs/LineshapesPdf.h
@@ -14,6 +14,9 @@ See *.cu file for more details
 
 #include <thrust/complex.h>
 
+namespace GooFit {
+
+
 class SpinFactor;
 
 enum class LS {ONE, BW, Lass, Lass_M3, nonRes, Bugg, Bugg3, Flatte, SBW};
@@ -85,3 +88,5 @@ private:
     std::vector<Lineshape*> _LS;
     unsigned int _nPerm;
 };
+} // namespace GooFit
+

--- a/include/goofit/PDFs/MappedPdf.h
+++ b/include/goofit/PDFs/MappedPdf.h
@@ -2,6 +2,9 @@
 
 #include "goofit/PDFs/GooPdf.h"
 
+namespace GooFit {
+
+
 class MappedPdf : public GooPdf {
 public:
     MappedPdf(std::string n, GooPdf* m, std::vector<GooPdf*>& t);
@@ -10,3 +13,5 @@ public:
 private:
 
 };
+} // namespace GooFit
+

--- a/include/goofit/PDFs/MetricTaker.h
+++ b/include/goofit/PDFs/MetricTaker.h
@@ -4,6 +4,9 @@
 
 #include "goofit/PdfBase.h"
 
+namespace GooFit {
+
+
 
 // Notice that operators are distinguished by the order of the operands,
 // and not otherwise! It's up to the user to make his tuples correctly.
@@ -38,4 +41,6 @@ private:
 
 };
 
+
+} // namespace GooFit
 

--- a/include/goofit/PDFs/MixingTimeResolution_Aux.h
+++ b/include/goofit/PDFs/MixingTimeResolution_Aux.h
@@ -3,6 +3,9 @@
 #include "goofit/GlobalCudaDefines.h"
 #include "goofit/PDFs/GooPdf.h"
 
+namespace GooFit {
+
+
 typedef fptype(*device_resfunction_ptr)(fptype, fptype, fptype, fptype, fptype, fptype, fptype, fptype, fptype, fptype*,
                                         unsigned int*);
 typedef fptype(*device_calc_tau_fcn_ptr)(fptype, fptype, fptype, fptype, fptype, fptype, fptype);
@@ -30,3 +33,5 @@ private:
     int resFunctionIdx;
     int resCalcTauFcnIdx;
 };
+} // namespace GooFit
+

--- a/include/goofit/PDFs/NovosibirskPdf.h
+++ b/include/goofit/PDFs/NovosibirskPdf.h
@@ -2,6 +2,9 @@
 
 #include "goofit/PDFs/GooPdf.h"
 
+namespace GooFit {
+
+
 class NovosibirskPdf : public GooPdf {
 public:
     NovosibirskPdf(std::string n, Variable* _x, Variable* m, Variable* s, Variable* t);
@@ -9,3 +12,5 @@ public:
 private:
 
 };
+} // namespace GooFit
+

--- a/include/goofit/PDFs/PolynomialPdf.h
+++ b/include/goofit/PDFs/PolynomialPdf.h
@@ -2,6 +2,9 @@
 
 #include "goofit/PDFs/GooPdf.h"
 
+namespace GooFit {
+
+
 class PolynomialPdf : public GooPdf {
 public:
     PolynomialPdf(std::string n, Variable* _x, std::vector<Variable*> weights, Variable* x0 = nullptr,
@@ -16,3 +19,5 @@ public:
 private:
     Variable* center;
 };
+} // namespace GooFit
+

--- a/include/goofit/PDFs/ProdPdf.h
+++ b/include/goofit/PDFs/ProdPdf.h
@@ -2,6 +2,9 @@
 
 #include "goofit/PDFs/GooPdf.h"
 
+namespace GooFit {
+
+
 class ProdPdf : public GooPdf {
 public:
 
@@ -14,3 +17,5 @@ public:
 private:
     bool varOverlaps; // True if any components share an observable.
 };
+} // namespace GooFit
+

--- a/include/goofit/PDFs/ResonancePdf.h
+++ b/include/goofit/PDFs/ResonancePdf.h
@@ -3,6 +3,9 @@
 #include "goofit/PDFs/GooPdf.h"
 #include <thrust/complex.h>
 
+namespace GooFit {
+
+
 typedef thrust::complex<fptype> (*resonance_function_ptr)(fptype, fptype, fptype, unsigned int*);
 
 __device__ fptype twoBodyCMmom(double rMassSq, fptype d1m, fptype d2m);
@@ -81,4 +84,6 @@ private:
     unsigned int resonance_type;
     */
 };
+
+} // namespace GooFit
 

--- a/include/goofit/PDFs/ScaledGaussianPdf.h
+++ b/include/goofit/PDFs/ScaledGaussianPdf.h
@@ -2,6 +2,9 @@
 
 #include "goofit/PDFs/GooPdf.h"
 
+namespace GooFit {
+
+
 class ScaledGaussianPdf : public GooPdf {
 public:
     ScaledGaussianPdf(std::string n, Variable* _x, Variable* m, Variable* s, Variable* d, Variable* e);
@@ -14,3 +17,5 @@ public:
 private:
 
 };
+} // namespace GooFit
+

--- a/include/goofit/PDFs/SmoothHistogramPdf.h
+++ b/include/goofit/PDFs/SmoothHistogramPdf.h
@@ -6,6 +6,9 @@
 #include <thrust/device_vector.h>
 #include <thrust/host_vector.h>
 
+namespace GooFit {
+
+
 class SmoothHistogramPdf : public GooPdf {
 public:
     SmoothHistogramPdf(std::string n, BinnedDataSet* x, Variable* smoothing);
@@ -23,3 +26,5 @@ private:
 
     static unsigned int totalHistograms;
 };
+} // namespace GooFit
+

--- a/include/goofit/PDFs/SpinFactors.h
+++ b/include/goofit/PDFs/SpinFactors.h
@@ -10,6 +10,9 @@ See *.cu file for more details
 
 #include "goofit/PDFs/DalitzPlotHelpers.h"
 
+namespace GooFit {
+
+
 typedef fptype(*spin_function_ptr)(fptype*, unsigned int*);
 
 enum class SF_4Body {
@@ -48,3 +51,5 @@ public:
         return (S.getName() == getName() and S._SF == _SF and S._P0 == _P0 and S._P1 == _P1 and S._P2 == _P2 and S._P3 == _P3);
     }
 };
+} // namespace GooFit
+

--- a/include/goofit/PDFs/SpinHelper.h
+++ b/include/goofit/PDFs/SpinHelper.h
@@ -10,6 +10,9 @@ This code is not sufficently tested yet and still under heavy development!
 
 #include "goofit/PDFs/DalitzPlotHelpers.h"
 
+namespace GooFit {
+
+
 class __align__(16) gpuLVec {
 private:
     fptype X;
@@ -522,4 +525,6 @@ __device__ inline gpuLVec LeviCivita(const gpuLVec& a, const gpuLVec& b, const g
 
     return  v;
 }
+
+} // namespace GooFit
 

--- a/include/goofit/PDFs/StepPdf.h
+++ b/include/goofit/PDFs/StepPdf.h
@@ -2,6 +2,9 @@
 
 #include "goofit/PDFs/GooPdf.h"
 
+namespace GooFit {
+
+
 class StepPdf : public GooPdf {
 public:
     StepPdf(std::string n, Variable* _x, Variable* x0);
@@ -15,3 +18,5 @@ public:
 private:
 
 };
+} // namespace GooFit
+

--- a/include/goofit/PDFs/Tddp4Pdf.h
+++ b/include/goofit/PDFs/Tddp4Pdf.h
@@ -16,6 +16,9 @@ See *.cu file for more details
 #include <thrust/remove.h>
 #include "goofit/PDFs/MixingTimeResolution_Aux.h"
 
+namespace GooFit {
+
+
 class LSCalculator_TD;
 class AmpCalc_TD;
 class SFCalculator_TD;
@@ -184,3 +187,5 @@ public:
                 thrust::get<3>(one) + thrust::get<3>(two));
     }
 };
+} // namespace GooFit
+

--- a/include/goofit/PDFs/TddpPdf.h
+++ b/include/goofit/PDFs/TddpPdf.h
@@ -4,6 +4,9 @@
 #include "goofit/PDFs/MixingTimeResolution_Aux.h"
 #include "goofit/PDFs/DalitzPlotHelpers.h"
 
+namespace GooFit {
+
+
 //thrust::tuple can't go down the read-only cache pipeline, so we are creating a structure for this.
 typedef struct {
     //note: combining these into a single transaction (double2) should improve memory performance
@@ -126,4 +129,6 @@ private:
     unsigned int parameters;
 };
 
+
+} // namespace GooFit
 

--- a/include/goofit/PDFs/ThreeGaussResolution_Aux.h
+++ b/include/goofit/PDFs/ThreeGaussResolution_Aux.h
@@ -2,6 +2,9 @@
 
 #include "goofit/PDFs/MixingTimeResolution_Aux.h"
 
+namespace GooFit {
+
+
 class ThreeGaussResolution : public MixingTimeResolution {
 public:
     ThreeGaussResolution(Variable* cf, Variable* tf, Variable* cb, Variable* cs, Variable* tb, Variable* ts, Variable* ob,
@@ -22,3 +25,5 @@ private:
     Variable* outBias;
     Variable* outScaleFactor;
 };
+} // namespace GooFit
+

--- a/include/goofit/PDFs/TrigThresholdPdf.h
+++ b/include/goofit/PDFs/TrigThresholdPdf.h
@@ -2,6 +2,9 @@
 
 #include "goofit/PDFs/GooPdf.h"
 
+namespace GooFit {
+
+
 class TrigThresholdPdf : public GooPdf {
 public:
     TrigThresholdPdf(std::string n, Variable* _x, Variable* thresh, Variable* trigConst, Variable* linConst,
@@ -12,3 +15,5 @@ public:
 private:
 
 };
+} // namespace GooFit
+

--- a/include/goofit/PDFs/TruthResolution_Aux.h
+++ b/include/goofit/PDFs/TruthResolution_Aux.h
@@ -2,6 +2,9 @@
 
 #include "goofit/PDFs/MixingTimeResolution_Aux.h"
 
+namespace GooFit {
+
+
 class TruthResolution : public MixingTimeResolution {
 public:
     TruthResolution();
@@ -13,3 +16,5 @@ public:
         pindices.push_back(0);
     }
 };
+} // namespace GooFit
+

--- a/include/goofit/PDFs/VoigtianPdf.h
+++ b/include/goofit/PDFs/VoigtianPdf.h
@@ -2,6 +2,9 @@
 
 #include "goofit/PDFs/GooPdf.h"
 
+namespace GooFit {
+
+
 class VoigtianPdf : public GooPdf {
 public:
     VoigtianPdf(std::string n, Variable* _x, Variable* m, Variable* s, Variable* w);
@@ -9,3 +12,5 @@ public:
 private:
 
 };
+} // namespace GooFit
+

--- a/include/goofit/PdfBase.h
+++ b/include/goofit/PdfBase.h
@@ -15,6 +15,8 @@ class TH1D;
 
 #include <Minuit2/FunctionMinimum.h>
 
+namespace GooFit {
+
 /* Future use, apperently:
 #include <thrust/iterator/constant_iterator.h>
 #include <thrust/device_vector.h>
@@ -133,4 +135,6 @@ private:
     __host__ void setIndices();
 };
 
+
+} // namespace GooFit
 

--- a/include/goofit/UnbinnedDataSet.h
+++ b/include/goofit/UnbinnedDataSet.h
@@ -6,6 +6,9 @@
 #include <vector>
 #include <initializer_list>
 
+namespace GooFit {
+
+
 class UnbinnedDataSet : public DataSet {
     // Class for unbinned datasets.
 
@@ -34,3 +37,5 @@ private:
     std::vector<std::vector<fptype>> data;
 
 };
+} // namespace GooFit
+

--- a/include/goofit/Variable.h
+++ b/include/goofit/Variable.h
@@ -7,11 +7,23 @@
 
 #include "goofit/GlobalCudaDefines.h"
 
+
 // Declaring friends
+
 namespace GooFit {
+    class Variable;
+}
+
+/// Nice print of Variable
+std::ostream& operator<< (std::ostream& o, const GooFit::Variable& var);
+
+/// Allow Variable to be read in
+std::istream& operator>> (std::istream& i, GooFit::Variable& var);
+
+namespace GooFit {
+
 class FCN;
 class Minuit1;
-}
 
 class Indexable {
 public:
@@ -76,8 +88,8 @@ protected:
 class Variable : public Indexable {
     friend GooFit::FCN;
     friend GooFit::Minuit1;
-    friend std::ostream& operator<< (std::ostream& o, const Variable& var);
-    friend std::istream& operator>> (std::istream& o, Variable& var);
+    friend std::ostream& ::operator<< (std::ostream& o, const Variable& var);
+    friend std::istream& ::operator>> (std::istream& o, Variable& var);
 public:
     
     // These classes can not be duplicated
@@ -216,14 +228,11 @@ public:
     virtual ~Constant() {}
 };
 
-/// Nice print of Variable
-std::ostream& operator<< (std::ostream& o, const Variable& var);
-
-/// Allow Variable to be read in
-std::istream& operator>> (std::istream& i, Variable& var);
-
 /// Get the max index of a variable from a list
 int max_index(const std::vector<Variable*> &vars);
 
 /// Get the max fitter index of a variable from a list
 int max_fitter_index(const std::vector<Variable*> &vars);
+
+}
+

--- a/include/goofit/Variable.h
+++ b/include/goofit/Variable.h
@@ -11,16 +11,6 @@
 // Declaring friends
 
 namespace GooFit {
-    class Variable;
-}
-
-/// Nice print of Variable
-std::ostream& operator<< (std::ostream& o, const GooFit::Variable& var);
-
-/// Allow Variable to be read in
-std::istream& operator>> (std::istream& i, GooFit::Variable& var);
-
-namespace GooFit {
 
 class FCN;
 class Minuit1;
@@ -88,8 +78,8 @@ protected:
 class Variable : public Indexable {
     friend GooFit::FCN;
     friend GooFit::Minuit1;
-    friend std::ostream& ::operator<< (std::ostream& o, const Variable& var);
-    friend std::istream& ::operator>> (std::istream& o, Variable& var);
+    friend std::ostream& operator<< (std::ostream& o, const Variable& var);
+    friend std::istream& operator>> (std::istream& o, Variable& var);
 public:
     
     // These classes can not be duplicated
@@ -234,5 +224,10 @@ int max_index(const std::vector<Variable*> &vars);
 /// Get the max fitter index of a variable from a list
 int max_fitter_index(const std::vector<Variable*> &vars);
 
+/// Nice print of Variable
+std::ostream& operator<< (std::ostream& o, const GooFit::Variable& var);
+
+/// Allow Variable to be read in
+std::istream& operator>> (std::istream& i, GooFit::Variable& var);
 }
 

--- a/include/goofit/detail/Abort.h
+++ b/include/goofit/detail/Abort.h
@@ -2,17 +2,17 @@
 
 #include <string>
 
-class PdfBase;
-
 namespace GooFit {
+
+class PdfBase;
 
 /// Smart abort that includes the file name and location, and prints a stack trace if possible
 void abort(std::string file, int line, std::string reason, const PdfBase* pdf = nullptr);
 
-}
+} // namespace GooFit
 
 /// Classic abort name
 [[deprecated("Use GooFit::abort instead")]]
-inline void abortWithCudaPrintFlush(std::string file, int line, std::string reason, const PdfBase* pdf = nullptr) {
+inline void abortWithCudaPrintFlush(std::string file, int line, std::string reason, const GooFit::PdfBase* pdf = nullptr) {
     GooFit::abort(file, line, reason, pdf);
 }

--- a/include/goofit/fitting/FitManagerMinuit1.h
+++ b/include/goofit/fitting/FitManagerMinuit1.h
@@ -4,10 +4,10 @@
 #include "goofit/Variable.h"
 #include <TMinuit.h>
 
-class PdfBase;
-
 namespace GooFit {
     
+class PdfBase;
+
 class Minuit1 : public TMinuit {
     PdfBase* pdfPointer;
     std::vector<Variable*> vars;

--- a/include/goofit/fitting/FitManagerMinuit2.h
+++ b/include/goofit/fitting/FitManagerMinuit2.h
@@ -6,10 +6,10 @@
 #include "goofit/GlobalCudaDefines.h"
 #include "goofit/fitting/FCN.h"
 
-class PdfBase;
-
 namespace GooFit {
     
+class PdfBase;
+
 enum class FitErrors : int {
     Valid = 0,
     NotRun = 50,

--- a/include/goofit/fitting/Params.h
+++ b/include/goofit/fitting/Params.h
@@ -5,13 +5,13 @@
 #include <Minuit2/MnUserParameterState.h>
 #include <vector>
 
-class PdfBase;
-class Variable;
 
 namespace Minuit2 = ROOT::Minuit2;
 
 namespace GooFit {
 
+class PdfBase;
+class Variable;
 class FCN;
     
 class Params : public Minuit2::MnUserParameters {

--- a/python/BinnedDataSet.cpp
+++ b/python/BinnedDataSet.cpp
@@ -2,8 +2,9 @@
 #include <goofit/Variable.h>
 #include <goofit/BinnedDataSet.h>
 
-namespace py = pybind11;
+using namespace GooFit;
 
+namespace py = pybind11;
 
 void init_BinnedDataSet(py::module &m) {
     py::class_<BinnedDataSet, DataSet>(m, "BinnedDataSet")

--- a/python/DataSet.cpp
+++ b/python/DataSet.cpp
@@ -4,6 +4,7 @@
 #include <goofit/DataSet.h>
 
 namespace py = pybind11;
+using namespace GooFit;
 
 template<class DataSetBase = DataSet>
 class PyDataSet : public DataSetBase {

--- a/python/FitManager.cpp
+++ b/python/FitManager.cpp
@@ -4,6 +4,7 @@
 #include <goofit/FitManager.h>
 
 namespace py = pybind11;
+using namespace GooFit;
 
 void init_FitManager(py::module &m) {
     py::class_<FitManager>(m, "FitManager")

--- a/python/PDFs/ExpPdf.cpp
+++ b/python/PDFs/ExpPdf.cpp
@@ -3,6 +3,7 @@
 #include <goofit/Variable.h>
 #include <goofit/PDFs/ExpPdf.h>
 
+using namespace GooFit;
 namespace py = pybind11;
 
 void init_ExpPdf(py::module &m) {

--- a/python/PDFs/GooPdf.cpp
+++ b/python/PDFs/GooPdf.cpp
@@ -3,6 +3,7 @@
 
 #include <goofit/PDFs/GooPdf.h>
 
+using namespace GooFit;
 namespace py = pybind11;
 
 void init_GooPdf(py::module &m) {

--- a/python/PdfBase.cpp
+++ b/python/PdfBase.cpp
@@ -7,6 +7,7 @@
 #include <goofit/PdfBase.h>
 
 namespace py = pybind11;
+using namespace GooFit;
 
 void init_PdfBase(py::module &m) {
     py::class_<PdfBase>(m, "PdfBase")

--- a/python/UnbinnedDataSet.cpp
+++ b/python/UnbinnedDataSet.cpp
@@ -4,6 +4,7 @@
 #include <goofit/UnbinnedDataSet.h>
 
 namespace py = pybind11;
+using namespace GooFit;
 
 void init_UnbinnedDataSet(py::module &m) {
     py::class_<UnbinnedDataSet, DataSet>(m, "UnbinnedDataSet")

--- a/python/Variable.cpp
+++ b/python/Variable.cpp
@@ -7,6 +7,7 @@
 
 namespace py = pybind11;
 using namespace fmt::literals;
+using namespace GooFit;
 
 void init_Variable(py::module &m) {
     py::class_<Indexable>(m, "Indexable")

--- a/scripts/AddNamespace.py
+++ b/scripts/AddNamespace.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+
+from __future__ import print_function
+
+from plumbum import local, cli
+import re
+
+expr = re.compile(r"#include")
+
+def add_namespace(lines, ns):
+    n = 0;
+    for v,line in enumerate(lines):
+        # Quit if already contains namespace
+        if 'namespace ' + ns in line:
+            return None
+
+        # Add namespace after last include
+        if ('#include' in line
+         or '#pragma once' in line):
+            n = v
+    lines.insert(n+1, '\nnamespace '+ns+' {\n\n')
+    lines.append(r"} // namespace " + ns + "\n\n")
+    return lines
+
+class AddNamespace(cli.Application):
+    namespace = cli.SwitchAttr('--name', str, default='GooFit', help='namespace to add')
+
+    @cli.positional(cli.ExistingFile)
+    def main(self, *filenames):
+        for fi in filenames:
+            with open(fi) as f:
+                lines = f.readlines()
+            lines = add_namespace(lines, self.namespace)
+            if lines is None:
+                print("Skipping", fi)
+                continue
+            with open(fi, 'w') as f:
+                f.write(''.join(lines))
+            print("Added namespace to", fi)
+
+if __name__ == '__main__':
+    AddNamespace()

--- a/src/PDFs/AddPdf.cu
+++ b/src/PDFs/AddPdf.cu
@@ -9,6 +9,8 @@
 #include <mpi.h>
 #endif
 
+namespace GooFit {
+
 __device__ fptype device_AddPdfs(fptype* evt, fptype* p, unsigned int* indices) {
     int numParameters = RO_CACHE(indices[0]);
     fptype ret = 0;
@@ -241,3 +243,5 @@ __host__ double AddPdf::sumOfNll(int numVars) const {
 
     return ret;
 }
+} // namespace GooFit
+

--- a/src/PDFs/AllPdfs.cu
+++ b/src/PDFs/AllPdfs.cu
@@ -42,3 +42,8 @@
 #include "MixingTimeResolution_Aux.cu"
 #include "TruthResolution_Aux.cu"
 #include "ThreeGaussResolution_Aux.cu"
+
+namespace GooFit {
+
+} // namespace GooFit
+

--- a/src/PDFs/ArgusPdf.cu
+++ b/src/PDFs/ArgusPdf.cu
@@ -1,6 +1,9 @@
 #include "goofit/PDFs/ArgusPdf.h"
 #include "goofit/Variable.h"
 
+namespace GooFit {
+
+
 __device__ fptype device_Argus_Upper(fptype* evt, fptype* p, unsigned int* indices) {
     fptype x = evt[indices[2 + indices[0]]];
     fptype m0 = p[indices[1]];
@@ -106,3 +109,5 @@ __host__ double ArgusPdf::integrate(fptype lo, fptype hi) const {
     norm *= ((hi - lo) / integrationBins);
     return norm;
 }
+} // namespace GooFit
+

--- a/src/PDFs/BWPdf.cu
+++ b/src/PDFs/BWPdf.cu
@@ -1,5 +1,8 @@
 #include "goofit/PDFs/BWPdf.h"
 
+namespace GooFit {
+
+
 __device__ fptype device_BW(fptype* evt, fptype* p, unsigned int* indices) {
     fptype x = evt[indices[2 + indices[0]]];
     fptype mean  = p[indices[1]];
@@ -19,3 +22,5 @@ __host__ BWPdf::BWPdf(std::string n, Variable* _x, Variable* mean, Variable* wid
     GET_FUNCTION_ADDR(ptr_to_BW);
     initialise(pindices);
 }
+} // namespace GooFit
+

--- a/src/PDFs/BifurGaussPdf.cu
+++ b/src/PDFs/BifurGaussPdf.cu
@@ -1,5 +1,8 @@
 #include "goofit/PDFs/BifurGaussPdf.h"
 
+namespace GooFit {
+
+
 __device__ fptype device_BifurGauss(fptype* evt, fptype* p, unsigned int* indices) {
     fptype x = evt[indices[2 + indices[0]]]; // why does indices recall itself?
     fptype mean = p[indices[1]];
@@ -43,3 +46,5 @@ __host__ fptype BifurGaussPdf::integrate(fptype lo, fptype hi) const {
 
     return .5* normL + .5*normR;
 }
+} // namespace GooFit
+

--- a/src/PDFs/BinTransformPdf.cu
+++ b/src/PDFs/BinTransformPdf.cu
@@ -1,5 +1,8 @@
 #include "goofit/PDFs/BinTransformPdf.h"
 
+namespace GooFit {
+
+
 __device__ fptype device_BinTransform(fptype* evt, fptype* p, unsigned int* indices) {
     // Index structure: nP lim1 bin1 lim2 bin2 ... nO o1 o2
     int numObservables = indices[1 + indices[0]];
@@ -52,4 +55,6 @@ __host__ BinTransformPdf::BinTransformPdf(std::string n, std::vector<Variable*> 
     initialise(pindices);
 }
 
+
+} // namespace GooFit
 

--- a/src/PDFs/CompositePdf.cu
+++ b/src/PDFs/CompositePdf.cu
@@ -1,5 +1,8 @@
 #include "goofit/PDFs/CompositePdf.h"
 
+namespace GooFit {
+
+
 __device__ fptype device_Composite(fptype* evt, fptype* p, unsigned int* indices) {
     unsigned int coreFcnIndex  = RO_CACHE(indices[1]);
     unsigned int coreParIndex  = RO_CACHE(indices[2]);
@@ -72,3 +75,5 @@ __host__ fptype CompositePdf::normalize() const {
     return GooPdf::normalize();
 
 }
+} // namespace GooFit
+

--- a/src/PDFs/ConvolutionPdf.cu
+++ b/src/PDFs/ConvolutionPdf.cu
@@ -5,6 +5,9 @@
 #include <thrust/iterator/constant_iterator.h>
 #include <thrust/iterator/counting_iterator.h>
 
+namespace GooFit {
+
+
 int totalConvolutions = 0;
 
 #define CONVOLUTION_CACHE_SIZE 512
@@ -332,4 +335,6 @@ __host__ fptype ConvolutionPdf::normalize() const {
 }
 
 
+
+} // namespace GooFit
 

--- a/src/PDFs/CorrGaussianPdf.cu
+++ b/src/PDFs/CorrGaussianPdf.cu
@@ -1,5 +1,8 @@
 #include "goofit/PDFs/CorrGaussianPdf.h"
 
+namespace GooFit {
+
+
 __device__ fptype device_CorrGaussian(fptype* evt, fptype* p, unsigned int* indices) {
     fptype x = evt[indices[2 + indices[0]]];
     fptype y = evt[indices[3 + indices[0]]];
@@ -40,4 +43,6 @@ __host__ CorrGaussianPdf::CorrGaussianPdf(std::string n, Variable* _x, Variable*
     initialise(pindices);
 }
 
+
+} // namespace GooFit
 

--- a/src/PDFs/CrystalBallPdf.cu
+++ b/src/PDFs/CrystalBallPdf.cu
@@ -1,6 +1,9 @@
 #include "goofit/PDFs/CrystalBallPdf.h"
 #include "goofit/Variable.h"
 
+namespace GooFit {
+
+
 __device__ fptype device_CrystalBall(fptype* evt, fptype* p, unsigned int* indices) {
     // Left-hand tail if alpha is less than 0,
     // right-hand tail if greater, pure Gaussian if 0.
@@ -109,4 +112,6 @@ __host__ fptype CrystalBallPdf::integrate(fptype lo, fptype hi) const {
 
     return result;
 }
+
+} // namespace GooFit
 

--- a/src/PDFs/DP4Pdf.cu
+++ b/src/PDFs/DP4Pdf.cu
@@ -24,6 +24,9 @@ TODO:
 #include "goofit/PDFs/EvalVar.h"
 #include "goofit/Error.h"
 
+namespace GooFit {
+
+
 
 // The function of this array is to hold all the cached waves; specific
 // waves are recalculated when the corresponding resonance mass or width
@@ -836,3 +839,5 @@ __device__ fptype NormIntegrator::operator()(thrust::tuple<int, int, fptype*, th
 
     return thrust::norm(returnVal);
 }
+} // namespace GooFit
+

--- a/src/PDFs/DalitzPlotHelpers.cu
+++ b/src/PDFs/DalitzPlotHelpers.cu
@@ -8,6 +8,9 @@ Helper functions
 
 #include "goofit/PDFs/DalitzPlotHelpers.h"
 
+namespace GooFit {
+
+
 __device__ fptype Mass(const fptype* P0) {
     return sqrt(-P0[0]*P0[0] - P0[1]*P0[1] - P0[2]*P0[2] + P0[3]*P0[3]);
 }
@@ -215,3 +218,5 @@ __device__ fptype getmass(const unsigned int& pair, fptype& d1, fptype& d2, cons
 
     return mpair;
 }
+} // namespace GooFit
+

--- a/src/PDFs/DalitzPlotPdf.cu
+++ b/src/PDFs/DalitzPlotPdf.cu
@@ -4,6 +4,9 @@
 #include <thrust/complex.h>
 #include <thrust/transform_reduce.h>
 
+namespace GooFit {
+
+
 
 const int resonanceOffset_DP = 4; // Offset of the first resonance into the parameter index array
 // Offset is number of parameters, constant index, number of resonances (not calculable
@@ -405,4 +408,6 @@ __device__ thrust::complex<fptype> SpecialResonanceCalculator::operator()(thrust
     //printf("Amplitude %f %f %f (%f, %f)\n ", m12, m13, m23, ret.real, ret.imag);
     return ret;
 }
+
+} // namespace GooFit
 

--- a/src/PDFs/DalitzVetoPdf.cu
+++ b/src/PDFs/DalitzVetoPdf.cu
@@ -1,6 +1,9 @@
 #include "goofit/PDFs/DalitzVetoPdf.h"
 #include "goofit/PDFs/DalitzPlotHelpers.h"
 
+namespace GooFit {
+
+
 __device__ fptype device_DalitzVeto(fptype* evt, fptype* p, unsigned int* indices) {
     fptype x         = evt[RO_CACHE(indices[2 + RO_CACHE(indices[0]) + 0])];
     fptype y         = evt[RO_CACHE(indices[2 + RO_CACHE(indices[0]) + 1])];
@@ -53,3 +56,5 @@ __host__ DalitzVetoPdf::DalitzVetoPdf(std::string n, Variable* _x, Variable* _y,
     GET_FUNCTION_ADDR(ptr_to_DalitzVeto);
     initialise(pindices);
 }
+} // namespace GooFit
+

--- a/src/PDFs/EventWeightedAddPdf.cu
+++ b/src/PDFs/EventWeightedAddPdf.cu
@@ -2,6 +2,9 @@
 #include "goofit/Error.h"
 #include "goofit/Log.h"
 
+namespace GooFit {
+
+
 __device__ fptype device_EventWeightedAddPdfs(fptype* evt, fptype* p, unsigned int* indices) {
     int numParameters = RO_CACHE(indices[0]);
     fptype ret = 0;
@@ -118,4 +121,6 @@ __host__ fptype EventWeightedAddPdf::normalize() const {
 
     return 1.0;
 }
+
+} // namespace GooFit
 

--- a/src/PDFs/ExpGausPdf.cu
+++ b/src/PDFs/ExpGausPdf.cu
@@ -1,5 +1,8 @@
 #include "goofit/PDFs/ExpGausPdf.h"
 
+namespace GooFit {
+
+
 __device__ fptype device_ExpGaus(fptype* evt, fptype* p, unsigned int* indices) {
     fptype x     = evt[RO_CACHE(indices[2 + RO_CACHE(indices[0])])];
     fptype mean  = RO_CACHE(p[RO_CACHE(indices[1])]);
@@ -28,4 +31,6 @@ ExpGausPdf::ExpGausPdf(std::string n, Variable* _x, Variable* mean, Variable* si
     initialise(pindices);
 }
 
+
+} // namespace GooFit
 

--- a/src/PDFs/ExpPdf.cu
+++ b/src/PDFs/ExpPdf.cu
@@ -1,6 +1,9 @@
 #include "goofit/PDFs/ExpPdf.h"
 #include "goofit/Error.h"
 
+namespace GooFit {
+
+
 __device__ fptype device_Exp(fptype* evt, fptype* p, unsigned int* indices) {
     fptype x = evt[indices[2 + indices[0]]];
     fptype alpha = p[indices[1]];
@@ -100,4 +103,6 @@ __host__ fptype ExpPdf::integrate(fptype lo, fptype hi) const {
     ret /= alpha;
     return ret;
 }
+
+} // namespace GooFit
 

--- a/src/PDFs/GaussianPdf.cu
+++ b/src/PDFs/GaussianPdf.cu
@@ -1,5 +1,8 @@
 #include "goofit/PDFs/GaussianPdf.h"
 
+namespace GooFit {
+
+
 
 __device__ fptype device_Gaussian(fptype* evt, fptype* p, unsigned int* indices) {
     fptype x = evt[RO_CACHE(indices[2 + RO_CACHE(indices[0])])];
@@ -33,4 +36,6 @@ __host__ fptype GaussianPdf::integrate(fptype lo, fptype hi) const {
     sigma *= root2*rootPi;
     return sigma;
 }
+
+} // namespace GooFit
 

--- a/src/PDFs/GooPdf.cu
+++ b/src/PDFs/GooPdf.cu
@@ -25,6 +25,9 @@
 #include <mpi.h>
 #endif
 
+namespace GooFit {
+
+
 // These variables are either function-pointer related (thus specific to this implementation)
 // or constrained to be in the CUDAglob translation unit by nvcc limitations; otherwise they
 // would be in PdfBase.
@@ -646,3 +649,5 @@ __host__ TH1D* GooPdf::plotToROOT(Variable* var, double normFactor, std::string 
     return ret;
 }
 #endif
+} // namespace GooFit
+

--- a/src/PDFs/IncoherentSumPdf.cu
+++ b/src/PDFs/IncoherentSumPdf.cu
@@ -5,6 +5,9 @@
 
 #include <thrust/transform_reduce.h>
 
+namespace GooFit {
+
+
 const int resonanceOffset_incoherent = 4; // Offset of the first resonance into the parameter index array.
 // Notice that this is different from the TddpPdf case because there's no time information.
 // In particular the offset consists of nP, constant index, number of resonances, and cache index.
@@ -317,4 +320,6 @@ const {
 
     return ret;
 }
+
+} // namespace GooFit
 

--- a/src/PDFs/InterHistPdf.cu
+++ b/src/PDFs/InterHistPdf.cu
@@ -2,6 +2,9 @@
 #include "goofit/Variable.h"
 #include <algorithm>
 
+namespace GooFit {
+
+
 __constant__ fptype* dev_base_interhists[100]; // Multiple histograms for the case of multiple PDFs
 #define OBS_CODE 4242424242
 // This number is presumably so high that it will never collide
@@ -179,3 +182,5 @@ __host__ InterHistPdf::InterHistPdf(std::string n,
 
     totalHistograms++;
 }
+} // namespace GooFit
+

--- a/src/PDFs/JohnsonSUPdf.cu
+++ b/src/PDFs/JohnsonSUPdf.cu
@@ -1,5 +1,8 @@
 #include "goofit/PDFs/JohnsonSUPdf.h"
 
+namespace GooFit {
+
+
 const fptype SQRT2PI = 2.506628;
 
 __device__ fptype device_JohnsonSU(fptype* evt, fptype* p, unsigned int* indices) {
@@ -38,3 +41,5 @@ __host__ JohnsonSUPdf::JohnsonSUPdf(std::string n, Variable* _x, Variable* mean,
 __host__ fptype JohnsonSUPdf::integrate(fptype lo, fptype hi) const {
     return 1.0; // Analytic integral included in device function! (Correct for minus to plus inf.)
 }
+} // namespace GooFit
+

--- a/src/PDFs/KinLimitBWPdf.cu
+++ b/src/PDFs/KinLimitBWPdf.cu
@@ -1,6 +1,9 @@
 #include "goofit/PDFs/KinLimitBWPdf.h"
 #include "goofit/Variable.h"
 
+namespace GooFit {
+
+
 __device__ fptype getMomentum(const fptype& mass, const fptype& pimass, const fptype& d0mass) {
     if(mass <= 0)
         return 0;
@@ -68,3 +71,5 @@ __host__ void KinLimitBWPdf::setMasses(fptype bigM, fptype smallM) {
     constants[1] = smallM;
     MEMCPY_TO_SYMBOL(functorConstants, constants, 2*sizeof(fptype), cIndex*sizeof(fptype), cudaMemcpyHostToDevice);
 }
+} // namespace GooFit
+

--- a/src/PDFs/LandauPdf.cu
+++ b/src/PDFs/LandauPdf.cu
@@ -1,5 +1,8 @@
 #include "goofit/PDFs/LandauPdf.h"
 
+namespace GooFit {
+
+
 // LANDAU pdf : algorithm from CERNLIB G110 denlan
 // same algorithm is used in GSL
 
@@ -86,4 +89,6 @@ __host__ LandauPdf::LandauPdf(std::string n, Variable* _x, Variable* mpv, Variab
     initialise(pindices);
 }
 
+
+} // namespace GooFit
 

--- a/src/PDFs/LineshapesPdf.cu
+++ b/src/PDFs/LineshapesPdf.cu
@@ -11,6 +11,9 @@ Also right now it is the home to some helper functions needed and an implementat
 #include "goofit/PDFs/LineshapesPdf.h"
 #include "goofit/PDFs/SpinFactors.h"
 
+namespace GooFit {
+
+
 
 // Form factors as in pdg http://pdg.lbl.gov/2012/reviews/rpp2012-rev-dalitz-analysis-formalism.pdf
 __device__ fptype BL_PRIME(fptype z2, fptype z02, int L) {
@@ -544,4 +547,6 @@ bool Amplitude::operator==(const Amplitude& A) const {
 }
 
 
+
+} // namespace GooFit
 

--- a/src/PDFs/MappedPdf.cu
+++ b/src/PDFs/MappedPdf.cu
@@ -1,5 +1,8 @@
 #include "goofit/PDFs/MappedPdf.h"
 
+namespace GooFit {
+
+
 __device__ fptype device_Mapped(fptype* evt, fptype* p, unsigned int* indices) {
     // Structure : nP mapFunctionIndex mapParamIndex functionIndex1 parameterIndex1 functionIndex2 parameterIndex2 ...
 
@@ -62,3 +65,5 @@ __host__ fptype MappedPdf::normalize() const {
     host_normalisation[parameters] = 1.0;
     return ret;
 }
+} // namespace GooFit
+

--- a/src/PDFs/MetricTaker.cu
+++ b/src/PDFs/MetricTaker.cu
@@ -19,6 +19,9 @@
 #include <thrust/iterator/constant_iterator.h>
 #include <thrust/iterator/zip_iterator.h>
 
+namespace GooFit {
+
+
 
 
 __device__ fptype MetricTaker::operator()(thrust::tuple<int, fptype*, int> t) const {
@@ -102,4 +105,6 @@ MetricTaker::MetricTaker(int fIdx, int pIdx)
     , parameters(pIdx) {
     // This constructor should only be used for binned evaluation, ie for integrals.
 }
+
+} // namespace GooFit
 

--- a/src/PDFs/MixingTimeResolution_Aux.cu
+++ b/src/PDFs/MixingTimeResolution_Aux.cu
@@ -1,9 +1,14 @@
 #include "goofit/PDFs/MixingTimeResolution_Aux.h"
 #include "goofit/PDFs/GooPdf.h"
 
+namespace GooFit {
+
+
 MixingTimeResolution::MixingTimeResolution() {}
 MixingTimeResolution::~MixingTimeResolution() {}
 
 void MixingTimeResolution::initIndex(void* dev_fcn_ptr) {
     resFunctionIdx = GooPdf::findFunctionIdx(dev_fcn_ptr);
 }
+} // namespace GooFit
+

--- a/src/PDFs/NovosibirskPdf.cu
+++ b/src/PDFs/NovosibirskPdf.cu
@@ -1,5 +1,8 @@
 #include "goofit/PDFs/NovosibirskPdf.h"
 
+namespace GooFit {
+
+
 __device__ fptype device_Novosibirsk(fptype* evt, fptype* p, unsigned int* indices) {
     fptype _Mean  = p[indices[1]];
     fptype _Sigma = p[indices[2]];
@@ -43,4 +46,6 @@ __host__ NovosibirskPdf::NovosibirskPdf(std::string n, Variable* _x, Variable* m
     GET_FUNCTION_ADDR(ptr_to_Novosibirsk);
     initialise(pindices);
 }
+
+} // namespace GooFit
 

--- a/src/PDFs/PdfBase.cu
+++ b/src/PDFs/PdfBase.cu
@@ -10,6 +10,9 @@
 #include <mpi.h>
 #endif
 
+namespace GooFit {
+
+
 // This is code that belongs to the PdfBase class, that is,
 // it is common across all implementations. But it calls on device-side
 // functions, and due to the nvcc translation-unit limitations, it cannot
@@ -421,3 +424,5 @@ gooError gooFree(void* ptr) {
     return (gooError) cudaFree(ptr);
 #endif
 }
+} // namespace GooFit
+

--- a/src/PDFs/PolynomialPdf.cu
+++ b/src/PDFs/PolynomialPdf.cu
@@ -1,6 +1,9 @@
 #include "goofit/PDFs/PolynomialPdf.h"
 #include "goofit/Variable.h"
 
+namespace GooFit {
+
+
 __device__ fptype device_Polynomial(fptype* evt, fptype* p, unsigned int* indices) {
     // Structure is nP lowestdegree c1 c2 c3 nO o1
 
@@ -232,3 +235,5 @@ __host__ fptype PolynomialPdf::getCoefficient(int coef) const {
     fptype param = host_params[indices[2 + coef - indices[1]]];
     return norm*param;
 }
+} // namespace GooFit
+

--- a/src/PDFs/ProdPdf.cu
+++ b/src/PDFs/ProdPdf.cu
@@ -1,6 +1,9 @@
 #include "goofit/PDFs/ProdPdf.h"
 #include <algorithm>
 
+namespace GooFit {
+
+
 __device__ fptype device_ProdPdfs(fptype* evt, fptype* p, unsigned int* indices) {
     // Index structure is nP | F1 P1 | F2 P2 | ...
     // where nP is number of parameters, Fs are function indices, and Ps are parameter indices
@@ -106,3 +109,5 @@ __host__ fptype ProdPdf::normalize() const {
 
     return 1.0;
 }
+} // namespace GooFit
+

--- a/src/PDFs/ResonancePdf.cu
+++ b/src/PDFs/ResonancePdf.cu
@@ -1,6 +1,9 @@
 #include "goofit/PDFs/ResonancePdf.h"
 #include "goofit/PDFs/DalitzPlotHelpers.h"
 
+namespace GooFit {
+
+
 __device__ fptype twoBodyCMmom(double rMassSq, fptype d1m, fptype d2m) {
     // For A -> B + C, calculate momentum of B and C in rest frame of A.
     // PDG 38.16.
@@ -432,4 +435,6 @@ ResonancePdf::ResonancePdf(std::string name,
 
 }
 
+
+} // namespace GooFit
 

--- a/src/PDFs/ScaledGaussianPdf.cu
+++ b/src/PDFs/ScaledGaussianPdf.cu
@@ -3,6 +3,9 @@
 
 //#include <limits>
 
+namespace GooFit {
+
+
 __device__ fptype device_ScaledGaussian(fptype* evt, fptype* p, unsigned int* indices) {
     fptype x = evt[0];
     fptype mean = p[indices[1]] + p[indices[3]];
@@ -30,4 +33,6 @@ __host__ ScaledGaussianPdf::ScaledGaussianPdf(std::string n, Variable* _x, Varia
     GET_FUNCTION_ADDR(ptr_to_ScaledGaussian);
     initialise(pindices);
 }
+
+} // namespace GooFit
 

--- a/src/PDFs/SmoothHistogramPdf.cu
+++ b/src/PDFs/SmoothHistogramPdf.cu
@@ -1,6 +1,9 @@
 #include "goofit/PDFs/SmoothHistogramPdf.h"
 #include "goofit/Variable.h"
 
+namespace GooFit {
+
+
 __constant__ fptype* dev_base_histograms[100]; // Multiple histograms for the case of multiple PDFs
 __constant__ fptype* dev_smoothed_histograms[100];
 unsigned int SmoothHistogramPdf::totalHistograms = 0;
@@ -219,3 +222,5 @@ __host__ fptype SmoothHistogramPdf::normalize() const {
     host_normalisation[parameters] = 1.0/ret;
     return ret;
 }
+} // namespace GooFit
+

--- a/src/PDFs/SpinFactors.cu
+++ b/src/PDFs/SpinFactors.cu
@@ -8,6 +8,9 @@ This code is not sufficently tested yet and still under heavy development!
 #include "goofit/PDFs/SpinFactors.h"
 #include "goofit/PDFs/SpinHelper.h"
 
+namespace GooFit {
+
+
 #define ZEMACH 1
 
 __device__ fptype DtoPP1_PtoSP2_StoP3P4(fptype* Vecs, unsigned int* indices) {
@@ -578,4 +581,6 @@ SpinFactor::SpinFactor(std::string name, SF_4Body SF, unsigned int P0, unsigned 
 
     initialise(pindices);
 }
+
+} // namespace GooFit
 

--- a/src/PDFs/StepPdf.cu
+++ b/src/PDFs/StepPdf.cu
@@ -1,5 +1,8 @@
 #include "goofit/PDFs/StepPdf.h"
 
+namespace GooFit {
+
+
 __device__ fptype device_Step(fptype* evt, fptype* p, unsigned int* indices) {
     fptype x = evt[indices[2 + indices[0]]];
     fptype x0 = p[indices[1]];
@@ -22,4 +25,6 @@ __host__ fptype StepPdf::integrate(fptype lo, fptype hi) const {
     fptype x0 = host_params[indices[1]];
     return (hi - x0);
 }
+
+} // namespace GooFit
 

--- a/src/PDFs/Tddp4Pdf.cu
+++ b/src/PDFs/Tddp4Pdf.cu
@@ -29,6 +29,9 @@ TODO:
 
 #include <thrust/complex.h>
 
+namespace GooFit {
+
+
 struct genExp {
     fptype gamma;
     unsigned int offset;
@@ -1154,4 +1157,6 @@ __device__ thrust::tuple<fptype, fptype, fptype, fptype> NormIntegrator_TD::oper
     auto AmpAB = AmpA*conj(AmpB);
     return thrust::tuple<fptype, fptype, fptype, fptype>(thrust::norm(AmpA), thrust::norm(AmpB), AmpAB.real(), AmpAB.imag());
 }
+
+} // namespace GooFit
 

--- a/src/PDFs/TddpPdf.cu
+++ b/src/PDFs/TddpPdf.cu
@@ -7,6 +7,8 @@
 #include <mpi.h>
 #endif
 
+namespace GooFit {
+
 const int resonanceOffset = 8; // Offset of the first resonance into the parameter index array
 // Offset is number of parameters, constant index, indices for tau, xmix, and ymix, index
 // of resolution function, and finally number of resonances (not calculable from nP
@@ -783,4 +785,6 @@ __device__ WaveHolder_s SpecialWaveCalculator::operator()(thrust::tuple<int, fpt
 
     return ret;
 }
+
+} // namespace GooFit
 

--- a/src/PDFs/ThreeGaussResolution_Aux.cu
+++ b/src/PDFs/ThreeGaussResolution_Aux.cu
@@ -1,5 +1,8 @@
 #include "goofit/PDFs/ThreeGaussResolution_Aux.h"
 #include <math.h>
+
+namespace GooFit {
+
 const fptype R1o6      = 1.0 / 6.0;
 #define SQRTPIo2 (1.0/M_2_SQRTPI)
 #define SQRT1o2PI (sqrt(0.5*M_1_PI))
@@ -145,3 +148,5 @@ fptype ThreeGaussResolution::normalisation(fptype di1, fptype di2, fptype di3, f
 
     return ret;
 }
+} // namespace GooFit
+

--- a/src/PDFs/TrigThresholdPdf.cu
+++ b/src/PDFs/TrigThresholdPdf.cu
@@ -1,5 +1,8 @@
 #include "goofit/PDFs/TrigThresholdPdf.h"
 
+namespace GooFit {
+
+
 __device__ fptype threshCalc(fptype distance, fptype linConst) {
     fptype ret = (distance > fptype(0.5) ? fptype(1) : (linConst + (1 - linConst) * sin(distance * fptype(3.14159265))));
     return ret;
@@ -101,3 +104,5 @@ __host__ TrigThresholdPdf::TrigThresholdPdf(std::string n, Variable* _x, Variabl
 
     initialise(pindices);
 }
+} // namespace GooFit
+

--- a/src/PDFs/TruthResolution_Aux.cu
+++ b/src/PDFs/TruthResolution_Aux.cu
@@ -1,5 +1,8 @@
 #include "goofit/PDFs/TruthResolution_Aux.h"
 
+namespace GooFit {
+
+
 __device__ fptype device_truth_resolution(fptype coshterm, fptype costerm, fptype sinhterm, fptype sinterm,
         fptype tau, fptype dtime, fptype xmixing, fptype ymixing, fptype /*sigma*/,
         fptype* /*p*/, unsigned int* /*indices*/) {
@@ -57,4 +60,6 @@ fptype TruthResolution::normalisation(fptype di1, fptype di2, fptype di3, fptype
 
     return ret;
 }
+
+} // namespace GooFit
 

--- a/src/PDFs/VoigtianPdf.cu
+++ b/src/PDFs/VoigtianPdf.cu
@@ -3,6 +3,9 @@
 #include "goofit/Faddeeva.h"
 #include <thrust/complex.h>
 
+namespace GooFit {
+
+
 #define M_2PI 6.28318530717958
 //#define ROOT2 1.41421356
 
@@ -316,4 +319,6 @@ __host__ VoigtianPdf::VoigtianPdf(std::string n, Variable* _x, Variable* m, Vari
     GET_FUNCTION_ADDR(ptr_to_Voigtian);
     initialise(pindices);
 }
+
+} // namespace GooFit
 

--- a/src/goofit/BinnedDataSet.cc
+++ b/src/goofit/BinnedDataSet.cc
@@ -6,6 +6,9 @@
 #include <functional>
 #include <numeric>
 
+namespace GooFit {
+
+
 // Special constructor for one variable
 BinnedDataSet::BinnedDataSet(Variable* var, std::string n)
     : DataSet(var, n) {
@@ -162,3 +165,5 @@ std::vector<size_t> BinnedDataSet::convertValuesToBins(const std::vector<fptype>
 
     return localBins;
 }
+} // namespace GooFit
+

--- a/src/goofit/DataSet.cc
+++ b/src/goofit/DataSet.cc
@@ -5,6 +5,9 @@
 #include <cstdlib>
 #include <climits>
 
+namespace GooFit {
+
+
 DataSet::DataSet(Variable* var, std::string n)
 : name(n), variables({var}) {
     generateName();
@@ -70,3 +73,5 @@ void DataSet::checkAllVars() const {
             throw GooFit::OutOfRange(v->getName(), v->getValue(), v->getLowerLimit(), v->getUpperLimit());
     }
 }
+} // namespace GooFit
+

--- a/src/goofit/Faddeeva.cc
+++ b/src/goofit/Faddeeva.cc
@@ -5,6 +5,9 @@
 
 #include <thrust/complex.h>
 
+namespace GooFit {
+
+
 #define M_2PI 6.28318530717958
 
 static fptype n1[12] = { 0.25, 1.0, 2.25, 4.0, 6.25, 9.0, 12.25, 16.0, 20.25, 25.0, 30.25, 36.0 };
@@ -151,3 +154,5 @@ fptype cpuvoigtian(fptype x, fptype m, fptype w, fptype s) {
     static const fptype rsqrtPi = 0.5641895835477563;
     return c*rsqrtPi*v.real();
 }
+} // namespace GooFit
+

--- a/src/goofit/FunctorWriter.cc
+++ b/src/goofit/FunctorWriter.cc
@@ -4,6 +4,9 @@
 #include "goofit/PdfBase.h"
 #include "goofit/Variable.h"
 
+namespace GooFit {
+
+
 void writeToFile(PdfBase* pdf, const char* fname) {
     std::vector<Variable*> params = pdf->getParameters();
 
@@ -100,3 +103,5 @@ void writeListOfNumbers(thrust::host_vector<fptype>& target, const char* fname) 
 
     writer.close();
 }
+} // namespace GooFit
+

--- a/src/goofit/PdfBase.cc
+++ b/src/goofit/PdfBase.cc
@@ -12,6 +12,9 @@
 #include "goofit/BinnedDataSet.h"
 #include "goofit/UnbinnedDataSet.h"
 
+namespace GooFit {
+
+
 fptype* dev_event_array;
 fptype host_normalisation[maxParams];
 fptype host_params[maxParams];
@@ -185,3 +188,5 @@ __host__ ROOT::Minuit2::FunctionMinimum PdfBase::fitTo(DataSet *data) {
     FitManager fitter{this};
     return fitter.fit();
 }
+} // namespace GooFit
+

--- a/src/goofit/UnbinnedDataSet.cc
+++ b/src/goofit/UnbinnedDataSet.cc
@@ -3,6 +3,9 @@
 #include "goofit/Error.h"
 #include "goofit/Log.h"
 
+namespace GooFit {
+
+
 // Special constructor for one variable
 UnbinnedDataSet::UnbinnedDataSet(Variable* var, std::string n)
 : DataSet(var, n) {
@@ -57,3 +60,5 @@ void UnbinnedDataSet::addEvent() {
         data.at(i++).push_back(v->getValue());
     numEventsAdded++;
 }
+} // namespace GooFit
+

--- a/src/goofit/Variable.cc
+++ b/src/goofit/Variable.cc
@@ -3,7 +3,7 @@
 
 #include <algorithm>
 
-std::ostream& operator<< (std::ostream& o, const Variable& var) {
+std::ostream& operator<< (std::ostream& o, const GooFit::Variable& var) {
     o << var.getName() << ": " << var.getValue() << " +/- " << var.getError();
     if(!var.fixed)
         o << " [" << var.getLowerLimit() << ", " << var.getUpperLimit() << "]";
@@ -17,9 +17,11 @@ std::ostream& operator<< (std::ostream& o, const Variable& var) {
     return o;
 }
 
-std::istream& operator>> (std::istream& i, Variable& var) {
+std::istream& operator>> (std::istream& i, GooFit::Variable& var) {
     return i >> var.value;
 }
+
+namespace GooFit {
 
 int max_index(const std::vector<Variable*> &vars) {
     const Variable* max_ind_ptr = *std::max_element(std::begin(vars),
@@ -36,3 +38,5 @@ int max_fitter_index(const std::vector<Variable*> &vars) {
                                                     {return a->getFitterIndex() < b->getFitterIndex();});
     return max_ind_ptr->getFitterIndex();
 }
+} // namespace GooFit
+

--- a/src/goofit/Variable.cc
+++ b/src/goofit/Variable.cc
@@ -3,23 +3,6 @@
 
 #include <algorithm>
 
-std::ostream& operator<< (std::ostream& o, const GooFit::Variable& var) {
-    o << var.getName() << ": " << var.getValue() << " +/- " << var.getError();
-    if(!var.fixed)
-        o << " [" << var.getLowerLimit() << ", " << var.getUpperLimit() << "]";
-    if(var.getIndex() >= 0)
-        o << " GooFit index: " << var.getIndex();
-    if(var.getFitterIndex() >= 0)
-        o << " Fitter index: " << var.getFitterIndex();
-    if(var.blind != 0)
-        o << " Blinded";
-    
-    return o;
-}
-
-std::istream& operator>> (std::istream& i, GooFit::Variable& var) {
-    return i >> var.value;
-}
 
 namespace GooFit {
 
@@ -38,5 +21,24 @@ int max_fitter_index(const std::vector<Variable*> &vars) {
                                                     {return a->getFitterIndex() < b->getFitterIndex();});
     return max_ind_ptr->getFitterIndex();
 }
+
+std::ostream& operator<< (std::ostream& o, const GooFit::Variable& var) {
+    o << var.getName() << ": " << var.getValue() << " +/- " << var.getError();
+    if(!var.fixed)
+        o << " [" << var.getLowerLimit() << ", " << var.getUpperLimit() << "]";
+    if(var.getIndex() >= 0)
+        o << " GooFit index: " << var.getIndex();
+    if(var.getFitterIndex() >= 0)
+        o << " Fitter index: " << var.getFitterIndex();
+    if(var.blind != 0)
+        o << " Blinded";
+    
+    return o;
+}
+
+std::istream& operator>> (std::istream& i, GooFit::Variable& var) {
+    return i >> var.value;
+}
+
 } // namespace GooFit
 

--- a/tests/BinnedTest.cu
+++ b/tests/BinnedTest.cu
@@ -13,6 +13,7 @@
 
 #include <random>
 
+using namespace GooFit;
 
 TEST(BinnedFit, SimpleFit) {
     

--- a/tests/BlindTest.cu
+++ b/tests/BlindTest.cu
@@ -11,6 +11,8 @@
 #include "goofit/fitting/FitManagerMinuit1.h"
 #endif
 
+using namespace GooFit;
+
 TEST(Simple, NoBlind) {
 
     // Independent variable.

--- a/tests/Minuit1Test.cu
+++ b/tests/Minuit1Test.cu
@@ -15,6 +15,7 @@
 #include <random>
 
 using namespace std;
+using namespace GooFit;
 
 TEST(Minuit1, SimpleFit) {
     

--- a/tests/NormalizeTest.cu
+++ b/tests/NormalizeTest.cu
@@ -13,6 +13,7 @@
 
 #include <random>
 
+using namespace GooFit;
 
 TEST(Normalize, Dual) {
     // Random number generation

--- a/tests/SimpleTest.cu
+++ b/tests/SimpleTest.cu
@@ -3,6 +3,8 @@
 #include "goofit/Variable.h"
 #include "goofit/UnbinnedDataSet.h"
 
+using namespace GooFit;
+
 TEST(Simple, UnbinnedAdding) {
 
     // Independent variable.

--- a/tests/UnbinnedTest.cu
+++ b/tests/UnbinnedTest.cu
@@ -14,6 +14,8 @@
 
 #include <random>
 
+using namespace GooFit;
+
 TEST(UnbinnedFit, SimpleFit) {
     
     // Random number generation


### PR DESCRIPTION
**All** GooFit objects now live in the `GooFit` namespace. Script added that helped in the conversion.

Things that override Nvidia functions are not in GooFit.