### PR TITLE
Pip build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,5 @@ goofit/__init__.py
 .cache/v/cache/lastfailed
 *.ipynb_checkpoints*
 *.pdf
+MANIFEST
+dist

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 # Get the git command
 find_package(Git QUIET)
 
-if(GIT_FOUND)
+if(GIT_FOUND AND EXISTS "${PROJECT_SOURCE_DIR}/.git")
 # Update submodules as needed
     option(GOOFIT_SUBMODULE "Check submodules during build" ON)
     if(GOOFIT_SUBMODULE)
@@ -85,7 +85,7 @@ endif()
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/extern/sanitizers/cmake" ${CMAKE_MODULE_PATH})
 find_package(Sanitizers)
 
-set(GOOFIT_MAXPAR "1800" CACHE STRING "The number of parameters to statically support, can be increased but should not be too large.") 
+set(GOOFIT_MAXPAR "1800" CACHE STRING "The number of parameters to statically support, can be increased but should not be too large.")
 
 # Output the current GooFit version
 configure_file (
@@ -114,7 +114,7 @@ set(CMAKE_CXX_VISIBILITY_PRESET hidden)
 
 if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wno-unknown-pragmas -Wno-long-long -Wno-attributes -Wno-sign-compare -Wno-unused-parameter")
-    # Helpful but irritating: -Wzero-as-null-pointer-constant -Wsuggest-override 
+    # Helpful but irritating: -Wzero-as-null-pointer-constant -Wsuggest-override
     # no-sign-compare can be removed, but will take some work to clean up
     # Same is true for no-unused-parameter
     # if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 5.0)

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,8 @@
 graft cmake
 graft extern
+graft python
+graft include
+graft goofit
+graft src
+graft tests
+include CMakeLists.txt LICENSE CONTRIBUTING.md CHANGELOG.md requirements.txt README.md

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+graft cmake
+graft extern

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 skbuild
 cmake
+numpy

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,18 @@ In practice, this looks like this:
     pip install scikit-build cmake
     pip install -v goofit
 
+
+## Building a source package from git
+
+For developers:
+
+To make a source package, start with a clean (such as new) git GooFit package with all submodules checked out.
+
+    git clone --branch=master --recursive --depth=10 git@github.com:GooFit/GooFit.git
+    cd goofit
+    python setup.py sdist
+    twine upload dist/*
+
 '''
         )
 

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,9 @@
-from skbuild import setup
+#!/usr/bin/env python
+try:
+    from skbuild import setup
+except ImportError:
+    print("Failed to find scikit-build, please run `pip install scikit-build cmake`)
+    raise
 
 setup(
         name='goofit',

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,22 @@ setup(
             '-DGOOFIT_PYTHON=ON',
             '-DGOOFIT_EXAMPLES=OFF'],
         license="LGPL 3.0",
-        packages=['goofit']
+        packages=['goofit'],
+        long_description='''\
+# GooFit for Python
+
+GooFit is a highly parallel fitting framework originally designed for High Energy Physics.
+
+## Installation
+
+This package can be installed with pip, but uses SciKit-Build, and is build, fully optimized, on your system. Because of this, there are a few caveats when running a pip install. Make sure you have SciKit-Build (`pip install scikit-build`) before you attempt an install. Also, if you don't have a recent version of CMake (3.8 or better recommended), also run `pip install cmake`. When you build, you should also use pip's `-v` flag, so that you can see it build (and observe the
+configuration options). Otherwise, you might wait a very long time without output (especially if CUDA was found).
+
+In practice, this looks like this:
+
+    pip install scikit-build cmake
+    pip install -v goofit
+
+'''
         )
 

--- a/setup.py
+++ b/setup.py
@@ -2,16 +2,17 @@ from skbuild import setup
 
 setup(
         name='goofit',
-        version='2.1',
+        version='2.1.0.dev1',
         description='GooFit fitting package',
         author='Henry Schreiner',
         author_email='hschrein@cern.ch',
         url='https://goofit.github.io',
         platforms = ["POSIX"],
         provides = ["goofit"],
-        cmake_args=['-DGOOFIT_PYTHON:BOOL=ON'],
+        cmake_args=[
+            '-DGOOFIT_PYTHON=ON',
+            '-DGOOFIT_EXAMPLES=OFF'],
         license="LGPL 3.0",
         packages=['goofit']
-        # description="A parallel fitting package."
         )
 

--- a/setup.py
+++ b/setup.py
@@ -2,12 +2,12 @@
 try:
     from skbuild import setup
 except ImportError:
-    print("Failed to find scikit-build, please run `pip install scikit-build cmake`)
+    print("Failed to find scikit-build, please run `pip install scikit-build cmake`")
     raise
 
 setup(
         name='goofit',
-        version='2.1.0.dev1',
+        version='2.1.0.dev2',
         description='GooFit fitting package',
         author='Henry Schreiner',
         author_email='hschrein@cern.ch',
@@ -20,26 +20,29 @@ setup(
         license="LGPL 3.0",
         packages=['goofit'],
         long_description='''\
-# GooFit for Python
+GooFit for Python
+-----------------
 
 GooFit is a highly parallel fitting framework originally designed for High Energy Physics.
 
-## Installation
+Installation
+============
 
-This package can be installed with pip, but uses SciKit-Build, and is build, fully optimized, on your system. Because of this, there are a few caveats when running a pip install. Make sure you have SciKit-Build (`pip install scikit-build`) before you attempt an install. Also, if you don't have a recent version of CMake (3.8 or better recommended), also run `pip install cmake`. When you build, you should also use pip's `-v` flag, so that you can see it build (and observe the
+This package can be installed with pip, but uses SciKit-Build, and is build, fully optimized, on your system. Because of this, there are a few caveats when running a pip install. Make sure you have SciKit-Build (``pip install scikit-build``) before you attempt an install. Also, if you don't have a recent version of CMake (3.8 or better recommended), also run ``pip install cmake``. When you build, you should also use pip's ``-v`` flag, so that you can see it build (and observe the
 configuration options). Otherwise, you might wait a very long time without output (especially if CUDA was found).
 
-In practice, this looks like this:
+In practice, this looks like this::
 
     pip install scikit-build cmake
     pip install -v goofit
 
 
-## Building a source package from git
+Building a source package from git
+==================================
 
 For developers:
 
-To make a source package, start with a clean (such as new) git GooFit package with all submodules checked out.
+To make a source package, start with a clean (such as new) git GooFit package with all submodules checked out::
 
     git clone --branch=master --recursive --depth=10 git@github.com:GooFit/GooFit.git
     cd goofit


### PR DESCRIPTION
`pip install goofit` is now supported! (dev version uploaded to PyPI). However, please use:
`pip install -v goofit`, so that you can see the CMake info as it builds. CUDA, OpenMP, and CPP should be supported.