### PR TITLE
WIP: Fixes nominuit

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -296,6 +296,7 @@ if(NOT ROOT_Minuit2_LIBRARY)
     add_subdirectory("extern/Minuit2")
     set_target_properties(Minuit2 PROPERTIES FOLDER extern)
     set_target_properties(Math PROPERTIES FOLDER extern)
+    add_library(ROOT::Minuit2 ALIAS Minuit2)
 endif()
 
 # Adding simple libraries

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -317,6 +317,9 @@ target_include_directories(rang INTERFACE "${PROJECT_SOURCE_DIR}/extern/rang/inc
 add_library(Eigen INTERFACE)
 target_include_directories(Eigen INTERFACE "${PROJECT_SOURCE_DIR}/extern/Eigen/Eigen")
 
+set(GOOFIT_ROOT_FOUND ROOT_FOUND)
+set(GOOFIT_ARCH_FLAGS ARCH_FLAGS)
+
 # Output the current GooFit version
 configure_file (
     "${PROJECT_SOURCE_DIR}/include/goofit/Version.h.in"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -495,7 +495,7 @@ endif()
 # This allows GOOFIT_PYTHON to be automatic
 set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/extern/pybind11/tools" ${CMAKE_MODULE_PATH})
 find_package(PythonLibsNew)
-if(PYTHONLIBS_FOUND)
+if(PYTHONLIBS_FOUND AND EXISTS PYTHON_LIBRARIES)
     option(GOOFIT_PYTHON "Python bindings for goofit" ON)
 else()
     option(GOOFIT_PYTHON "Python bindings for goofit" OFF)

--- a/include/goofit/PdfBase.h
+++ b/include/goofit/PdfBase.h
@@ -15,7 +15,11 @@
 class TH1D;
 #endif
 
-#include <Minuit2/FunctionMinimum.h>
+namespace ROOT {
+namespace Minuit2 {
+class FunctionMinimum;
+}
+}
 
 namespace GooFit {
 

--- a/include/goofit/Version.h.in
+++ b/include/goofit/Version.h.in
@@ -18,6 +18,6 @@
 #define GOOFIT_DEVICE "@GOOFIT_DEVICE@"
 #define GOOFIT_HOST "@GOOFIT_HOST@"
 
-#cmakedefine01 ARCH_FLAGS
-#cmakedefine01 ROOT_FOUND
+#cmakedefine01 GOOFIT_ARCH_FLAGS
+#cmakedefine01 GOOFIT_ROOT_FOUND
 

--- a/python/goofit/PdfBase.cpp
+++ b/python/goofit/PdfBase.cpp
@@ -6,6 +6,8 @@
 #include <goofit/UnbinnedDataSet.h>
 #include <goofit/PdfBase.h>
 
+#include <Minuit2/FunctionMinimum.h>
+
 namespace py = pybind11;
 using namespace GooFit;
 using namespace pybind11::literals;

--- a/python/goofit/Version.cpp
+++ b/python/goofit/Version.cpp
@@ -11,6 +11,6 @@ void init_Version(py::module &m) {
     m.attr("CMAKE_BUILD_TYPE")  = CMAKE_BUILD_TYPE;
     m.attr("GOOFIT_DEVICE")     = GOOFIT_DEVICE;
     m.attr("GOOFIT_HOST")       = GOOFIT_HOST;
-    m.attr("ARCH_FLAGS")        = ARCH_FLAGS;
-    m.attr("ROOT_FOUND")        = ROOT_FOUND;
+    m.attr("ARCH_FLAGS")        = GOOFIT_ARCH_FLAGS;
+    m.attr("ROOT_FOUND")        = GOOFIT_ROOT_FOUND;
 }

--- a/src/goofit/CMakeLists.txt
+++ b/src/goofit/CMakeLists.txt
@@ -16,6 +16,8 @@ goofit_add_library(FitManager2
     ${PROJECT_SOURCE_DIR}/include/goofit/fitting/Params.h
     )
 
+target_link_libraries(FitManager2 ROOT::Minuit2)
+
 goofit_add_library(Faddeeva
     Faddeeva.cc
     ${PROJECT_SOURCE_DIR}/include/goofit/Faddeeva.h
@@ -59,6 +61,8 @@ goofit_add_library(PdfBase
     )
 
 target_link_libraries(PdfBase backtrace)
+# Safe to use ROOT::Minuit2 even if ROOT not found
+target_link_libraries(PdfBase ROOT::Minuit2)
 
 
 # Note: order is important on Linux, derived classes first

--- a/src/goofit/PdfBase.cc
+++ b/src/goofit/PdfBase.cc
@@ -13,6 +13,8 @@
 #include "goofit/FitManager.h"
 #include "goofit/UnbinnedDataSet.h"
 
+#include <Minuit2/FunctionMinimum.h>
+
 namespace GooFit {
 
 fptype *dev_event_array;


### PR DESCRIPTION
Fixes based on OpenSUSE docker and missing Minuit2 option for ROOT. Addresses #101.

This means you can now build and use GooFit with a copy of ROOT without Minuit2, since GooFit can use the stand-alone Minuit2 library.