### PR TITLE
Dalitz plotter tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ CMakeLists.txt.user
 
 
 goofit/__init__.py
+goofit/__main__.py
 
 .cache/v/cache/lastfailed
 *.ipynb_checkpoints*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+
+## v2.1.1: Better Python
+#### (in progress)
+
+GooFit has received a few bugfixes that needed to be made available before the 2.2 merge. These include:
+
+* More complete Python examples ([2437af9], [#131])
+* DalitzPlotter helpers ([#131])
+* Regression fix: FeatureDetector now respects current compilation options ([#131])
+
+[#131]: https://github.com/GooFit/GooFit/pull/131
+[2437af9]: https://github.com/GooFit/GooFit/commit/2437af9958e8534aa299b754a4e4361ae18d5301
+
 ## v2.1.0: Python bindings
 #### December 7, 2017
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -402,6 +402,10 @@ add_subdirectory("extern/FeatureDetector")
 set_target_properties(FeatureDetector PROPERTIES FOLDER extern)
 target_link_libraries(GooFit_Common INTERFACE FeatureDetector)
 
+target_compile_options(FeatureDetector PRIVATE
+    $<BUILD_INTERFACE:${GOOFIT_OPTI}>
+    )
+
 ## format (warning suppesion only needed until next release)
 if(NOT DEFINED CMAKE_SUPPRESS_DEVELOPER_WARNINGS)
     set(CMAKE_SUPPRESS_DEVELOPER_WARNINGS 1 CACHE BOOL "")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,9 +4,9 @@ project(GOOFIT
     VERSION 2.1.1
     LANGUAGES CXX)
 
-set(GOOFIT_TAG "dev")
+#set(GOOFIT_TAG "dev")
 #set(GOOFIT_TAG "alpha")
-#set(GOOFIT_TAG "beta")
+set(GOOFIT_TAG "beta")
 #set(GOOFIT_TAG "release")
 
 ### Require out-of-source builds
@@ -428,7 +428,11 @@ add_library(Eigen INTERFACE)
 target_include_directories(Eigen SYSTEM INTERFACE "${PROJECT_SOURCE_DIR}/extern/Eigen")
 target_link_libraries(GooFit_Common INTERFACE Eigen)
 
-set(GOOFIT_ROOT_FOUND ROOT_FOUND)
+# This if(ROUND_FOUND) wrapper in theory should not be needed
+# But for some reason FALSE is not "falsy" to the define command
+if(ROOT_FOUND)
+    set(GOOFIT_ROOT_FOUND ROOT_FOUND)
+endif()
 set(GOOFIT_ARCH_FLAGS ARCH_FLAGS)
 
 option(GOOFIT_SPLASH "Show a unicode splash or a small plain text one" ON)

--- a/Pipfile
+++ b/Pipfile
@@ -14,7 +14,6 @@ numpy = "*"
 
 [dev-packages]
 
-"e1839a8" = {path = ".", editable = true}
 pytest = "*"
 matplotlib = "*"
 pandas = "*"

--- a/Pipfile
+++ b/Pipfile
@@ -1,15 +1,20 @@
 [[source]]
+
 url = "https://pypi.python.org/simple"
 verify_ssl = true
 name = "pypi"
 
+
 [packages]
-"scikit-build" = "*"
+
+scikit-build = "*"
 cmake = "*"
 numpy = "*"
 
 
 [dev-packages]
+
+"e1839a8" = {path = ".", editable = true}
 pytest = "*"
 matplotlib = "*"
 pandas = "*"

--- a/README.md
+++ b/README.md
@@ -22,12 +22,12 @@ doing maximum-likelihood fits with a familiar syntax.
 ## Requirements
 
 * A recent version of CMake is required. The minimum is 3.4, but tested primarily with 3.6 and newer. CMake is incredibly easy to install (see [the system install page](./docs/SYSTEM_INSTALL.md)).
-* A ROOT 6 build highly recommended -- GooFit will use the included Minuit2 submodule if ROOT is not found, and the Minuit1 based fitter will not be available.
+* A ROOT 6 build highly recommended -- GooFit will use the included Minuit2 submodule if ROOT is not found, and the Minuit1 based fitter will not be available. For CUDA, please use 6.08 (newer versions crash the NVCC compiler).
 
 <details><summary>If using CUDA: (click to expand)</summary><p>
 
 * CMake 3.8+ highly recommended, but not required (yet)
-* CUDA 7.0+
+* CUDA 7.0-8.0. CUDA 9+ not yet supported. Requires ROOT 6.08 (6.10 and 6.12 crash NVCC when compiling).
 * An nVidia GPU supporting compute capability at least 2.0 (3.5+ recommended)
 
 </p></details>

--- a/docs/SYSTEM_INSTALL.md
+++ b/docs/SYSTEM_INSTALL.md
@@ -1,15 +1,13 @@
 # Installing GooFit on different systems
 
-The Docker command for each system is listed at the beginning of each command, to show setup from scratch. Ignore that line if you are not using Docker.
+The following commands show you how to get a *minimal* install of GooFit on a vanilla system; you will probably want to add ROOT for your system, and possibly CUDA if you have a graphics card. If you do not have ROOT, some functionality, such as the Minuit1 version of the fitter, will not be available, and most of the examples will not be included in the build. Since ROOT is such a common addition, some of the system also have a note on installing ROOT.
 
-The following commands show you how to get a *minimal* install of GooFit on a vanilla system; you will probably want to add ROOT for your system, and possibly CUDA if you have a graphics card. If you do not have ROOT, some functionality, such as the Minuit1 version of the fitter, will not be available, and most of the examples will not be included in the build.
+<details><summary>CentOS 7: (click to expand)</summary><p>
 
-## CentOS 7
-
-For simplicity, this uses EPEL to get access to `python-pip`, and uses the pip version of CMake. Feel free to download CMake directly from Kitware instead. You can also use this recipe with an [nvidia-docker CentOS image](https://hub.docker.com/r/nvidia/cuda/).
+For simplicity, this uses EPEL to get access to `python-pip`, and uses the pip version of CMake. Feel free to download CMake directly from Kitware instead. If you want to use Docker, you can start with `docker run -it centos`.
+You can also use this recipe with an [nvidia-docker CentOS image](https://hub.docker.com/r/nvidia/cuda/).
 
 ```bash
-docker run -it centos
 yum install epel-release -y
 yum install python-pip git gcc-c++ make -y
 pip install cmake plumbum
@@ -28,10 +26,11 @@ If you'd like to add ROOT, add the following lines before running CMake:
 mkdir root-6 && curl https://root.cern.ch/download/root_v6.08.06.Linux-centos7-x86_64-gcc4.8.tar.gz | tar --strip-components=1 -xz -C root-6
 source root-6/bin/thisroot.sh
 ```
+</p></details>
 
-## Alpine Linux 3.5
+<details><summary>Alpine Linux 3.6: (click to expand)</summary><p>
 
-A truly minimal system, Alpine gives you a working Docker system under 3 MB.
+A truly minimal system, Alpine gives you a working Docker system under 3 MB. Since it is unlikely that you'll be running Alpine outside of Docker, the Docker command is included.
 
 ```bash
 docker run -it alpine
@@ -65,12 +64,14 @@ pip install scikit-build
 pip -v install git+https://github.com/GooFit/GooFit.git
 ```
 
-## Ubuntu 16.04
+</p></details>
 
-Ubiquitous Ubuntu works also. Ubuntu was used for the NVidia docker solution due to better support from NVidia. The following example uses ninja-build instead of make, but make works if you perfer it. You should also be able to use this recipe with an [nvidia-docker Ubuntu image](https://hub.docker.com/r/nvidia/cuda/).
+<details><summary>Ubuntu 16.04 (click to expand)</summary><p>
+
+Ubiquitous Ubuntu works also. Ubuntu was used for the NVidia Docker solution due to better support from NVidia. The following example uses `ninja-build` instead of make, but make works if you prefer it. You should also be able to use this recipe with  `docker run -it ubuntu` or
+an [nvidia-docker Ubuntu image](https://hub.docker.com/r/nvidia/cuda/) if you don't have Ubuntu installed.
 
 ```bash
-docker run -it ubuntu
 apt-get update && apt-get install -y git cmake ninja-build g++
 git clone --recursive https://github.com/GooFit/GooFit.git
 cd GooFit
@@ -87,12 +88,16 @@ mkdir root-6 && curl https://root.cern.ch/download/root_v6.08.06.Linux-ubuntu16-
 source root-6/bin/thisroot.sh
 ```
 
-## OpenSUSE
+</p></details>
+
+<details><summary>OpenSUSE (click to expand)</summary><p>
 
 If you use `make`, adding `-jN` where `N` is the number of cores will make builds much faster on multicore systems! `ninja` does this automatically.
+If you'd like to use Docker to provide an OpenSUSE environment, add
+`docker run -it opensuse sh`
+to the beginning of these commands.
 
 ```bash
-docker run -it opensuse sh
 zypper install -y git cmake gcc-c++
 git clone --recursive https://github.com/GooFit/GooFit.git
 cd GooFit
@@ -121,9 +126,11 @@ source /opt/root-6-10-04/bin/thisroot.sh
 
 You might want to add useful extra ROOT library: `-Droofit=ON -Dmathmore=ON -Dminuit2=ON`
 
-## Docker
+</p></details>
 
-If you are interested in actually running on Docker, you can use the official repositories:
+<details><summary>Docker (click to expand)</summary><p>
+
+If you are interested in actually running on Docker, you can use the official GooFit Docker images:
 
 ```bash
 docker run -it goofit/goofit-omp
@@ -140,7 +147,9 @@ cd GooFit
 make
 ```
 
-## Note on CMake install
+</p></details>
+
+<details><summary>Note about installing CMake: (click to expand)</summary><p>
 
 While other install methods for CMake, like `pip`, are easier, this way should always work. On Linux, you can manually get a version of CMake using:
 
@@ -156,3 +165,5 @@ If you are a fan of using `~/.local` and already have `~/.local/bin` in your pat
 ```bash
 wget -qO- "https://cmake.org/files/v3.9/cmake-3.9.4-Linux-x86_64.tar.gz" | tar --strip-components=1 -xz -C ~/.local
 ```
+
+</p></details>

--- a/examples/2d_plot/2d_plot.cu
+++ b/examples/2d_plot/2d_plot.cu
@@ -4,12 +4,12 @@
 #include <goofit/PDFs/combine/ProdPdf.h>
 #include <goofit/UnbinnedDataSet.h>
 #include <goofit/Variable.h>
+#include <goofit/detail/Style.h>
 
 #include <RVersion.h>
 #include <TCanvas.h>
 #include <TH1F.h>
 #include <TH2F.h>
-#include <TStyle.h>
 
 #include <iostream>
 #include <random>
@@ -29,21 +29,7 @@ int main(int argc, char **argv) {
     std::normal_distribution<> dx(0.2, 1.1);
     std::normal_distribution<> dy(0.5, 0.3);
 
-    gStyle->SetCanvasBorderMode(0);
-    gStyle->SetCanvasColor(10);
-    gStyle->SetFrameFillColor(10);
-    gStyle->SetFrameBorderMode(0);
-    gStyle->SetPadColor(0);
-    gStyle->SetTitleColor(1);
-    gStyle->SetStatColor(0);
-    gStyle->SetFillColor(0);
-    gStyle->SetFuncWidth(1);
-    gStyle->SetLineWidth(1);
-    gStyle->SetLineColor(1);
-    if(ROOT_VERSION_CODE < ROOT_VERSION(6, 6, 0))
-        gStyle->SetPalette(kRainBow, 0);
-    else
-        gStyle->SetPalette(kViridis, 0);
+    GooFit::setROOTStyle();
 
     Observable xvar{"xvar", -5, 5};
     Observable yvar{"yvar", -5, 5};

--- a/examples/dalitz/dalitz.cu
+++ b/examples/dalitz/dalitz.cu
@@ -55,11 +55,11 @@ fptype cpuGetM23(fptype massPZ, fptype massPM) {
 void getToyData(std::string toyFileName, GooFit::Application &app, DataSet &data) {
     toyFileName = app.get_filename(toyFileName, "examples/dalitz");
 
-    auto obs = data.getObservables();
-    Observable m12 = obs.at(0);
-    Observable m13 = obs.at(1);
+    auto obs               = data.getObservables();
+    Observable m12         = obs.at(0);
+    Observable m13         = obs.at(1);
     Observable eventNumber = obs.at(2);
-    
+
     TH2F dalitzplot("dalitzplot",
                     "",
                     m12.getNumBins(),
@@ -134,11 +134,7 @@ void getToyData(std::string toyFileName, GooFit::Application &app, DataSet &data
     foo.SaveAs("dalitzplot.png");
 }
 
-void makeToyData(DalitzPlotter &dplotter, UnbinnedDataSet &data) {
-
-    
-}
-
+void makeToyData(DalitzPlotter &dplotter, UnbinnedDataSet &data) {}
 
 DalitzPlotPdf *makeSignalPdf(Observable m12, Observable m13, EventNumber eventNumber, GooPdf *eff = 0) {
     DecayInfo3 dtop0pp;
@@ -314,8 +310,8 @@ DalitzPlotPdf *makeSignalPdf(Observable m12, Observable m13, EventNumber eventNu
     dtop0pp.resonances.push_back(f2_1270);
     dtop0pp.resonances.push_back(f0_600);
 
-    bool fitMasses = true;
-    
+    bool fitMasses = false;
+
     if(!fitMasses) {
         for(vector<ResonancePdf *>::iterator res = dtop0pp.resonances.begin(); res != dtop0pp.resonances.end(); ++res) {
             (*res)->setParameterConstantness(true);
@@ -339,8 +335,7 @@ DalitzPlotPdf *makeSignalPdf(Observable m12, Observable m13, EventNumber eventNu
     return new DalitzPlotPdf("signalPDF", m12, m13, eventNumber, dtop0pp, eff);
 }
 
-int runToyFit(DalitzPlotPdf* signal, UnbinnedDataSet* data) {
-
+int runToyFit(DalitzPlotPdf *signal, UnbinnedDataSet *data) {
     // EXERCISE 1 (real part): Create a PolynomialPdf which models
     // the efficiency you imposed in the preliminary, and use it in constructing
     // the signal PDF.
@@ -361,7 +356,7 @@ int runToyFit(DalitzPlotPdf* signal, UnbinnedDataSet* data) {
     DalitzPlotter plotter(&prodpdf, signal);
 
     TCanvas foo;
-    TH2F* dalitzplot = plotter.make2D();
+    TH2F *dalitzplot = plotter.make2D();
     dalitzplot->Draw("colz");
 
     foo.SaveAs("dalitzpdf.png");

--- a/examples/dalitz/dalitz.cu
+++ b/examples/dalitz/dalitz.cu
@@ -7,8 +7,6 @@
 #include <TLine.h>
 #include <TRandom.h>
 #include <TRandom3.h>
-#include <TStyle.h>
-#include <TText.h>
 
 // System stuff
 #include <fstream>
@@ -28,6 +26,7 @@
 #include <goofit/PDFs/physics/ResonancePdf.h>
 #include <goofit/UnbinnedDataSet.h>
 #include <goofit/Variable.h>
+#include <goofit/detail/Style.h>
 
 using namespace std;
 using namespace GooFit;
@@ -370,32 +369,14 @@ int runToyFit(std::string toyFileName, GooFit::Application &app) {
 
     datapdf.fit();
 
-    TH2F dalitzplot("dalitzplot",
-                    "",
-                    m12.getNumBins(),
-                    m12.getLowerLimit(),
-                    m12.getUpperLimit(),
-                    m13.getNumBins(),
-                    m13.getLowerLimit(),
-                    m13.getUpperLimit());
+    ProdPdf prodpdf{"prodpdf", {signal}};
 
-    /* Still segfaults for unknown reasons.
-    DalitzPlotter plotter(signal, signal);
+    DalitzPlotter plotter(&prodpdf, signal);
 
-    for (unsigned int j = 0; j < plotter.getNumEvents(); ++j) {
+    TH2F* dalitzplot = plotter.make2D();
+    dalitzplot->Draw("colz");
 
-        double currm12 = plotter.getXval(j);
-        double currm13 = plotter.getYval(j);
-        double currm23 = plotter.getZval(j);
-        double val = plotter.getVal(j);
-
-        dalitzplot.Fill(currm12, currm13, val);
-    }
-
-    dalitzplot.SetStats(false);
-    dalitzplot.Draw("colz");
     foodal->SaveAs("dalitzpdf.png");
-    */
 
     return datapdf;
 }
@@ -408,18 +389,8 @@ int main(int argc, char **argv) {
 
     GOOFIT_PARSE(app);
 
-    gStyle->SetCanvasBorderMode(0);
-    gStyle->SetCanvasColor(10);
-    gStyle->SetFrameFillColor(10);
-    gStyle->SetFrameBorderMode(0);
-    gStyle->SetPadColor(0);
-    gStyle->SetTitleColor(1);
-    gStyle->SetStatColor(0);
-    gStyle->SetFillColor(0);
-    gStyle->SetFuncWidth(1);
-    gStyle->SetLineWidth(1);
-    gStyle->SetLineColor(1);
-    gStyle->SetPalette(1, 0);
+    GooFit::setROOTStyle();
+
     foo    = new TCanvas();
     foodal = new TCanvas();
     foodal->Size(10, 10);

--- a/examples/dalitz/dalitz.cu
+++ b/examples/dalitz/dalitz.cu
@@ -23,6 +23,7 @@
 #include <goofit/PDFs/combine/AddPdf.h>
 #include <goofit/PDFs/combine/ProdPdf.h>
 #include <goofit/PDFs/physics/DalitzPlotPdf.h>
+#include <goofit/PDFs/physics/DalitzPlotter.h>
 #include <goofit/PDFs/physics/DalitzVetoPdf.h>
 #include <goofit/PDFs/physics/ResonancePdf.h>
 #include <goofit/UnbinnedDataSet.h>
@@ -369,10 +370,32 @@ int runToyFit(std::string toyFileName, GooFit::Application &app) {
 
     datapdf.fit();
 
-    // Segfault
-    // UnbinnedDataSet grid = signal->makeGrid();
-    // signal->setData(&grid);
-    // auto vecvec = signal->getCompProbsAtDataPoints();
+    TH2F dalitzplot("dalitzplot",
+                    "",
+                    m12.getNumBins(),
+                    m12.getLowerLimit(),
+                    m12.getUpperLimit(),
+                    m13.getNumBins(),
+                    m13.getLowerLimit(),
+                    m13.getUpperLimit());
+
+    /* Still segfaults for unknown reasons.
+    DalitzPlotter plotter(signal, signal);
+
+    for (unsigned int j = 0; j < plotter.getNumEvents(); ++j) {
+
+        double currm12 = plotter.getXval(j);
+        double currm13 = plotter.getYval(j);
+        double currm23 = plotter.getZval(j);
+        double val = plotter.getVal(j);
+
+        dalitzplot.Fill(currm12, currm13, val);
+    }
+
+    dalitzplot.SetStats(false);
+    dalitzplot.Draw("colz");
+    foodal->SaveAs("dalitzpdf.png");
+    */
 
     return datapdf;
 }

--- a/include/goofit/Application.h
+++ b/include/goofit/Application.h
@@ -280,13 +280,12 @@ class Application : public CLI::App {
 #endif
     }
 
-    /// Cleanup MPI
-    ~Application() {
-// Intentionally empty, comment needed to avoid clang warning about = default
+/// Cleanup MPI
 #ifdef GOOFIT_MPI
-        MPI_Finalize();
+    ~Application() { MPI_Finalize(); }
+#else
+    ~Application() = default;
 #endif
-    }
 
     /// Get a file from the current directory, looks up one and in the true current directory
     /// Base gives a relative path from the source directory

--- a/include/goofit/PDFs/physics/DalitzPlotHelpers.h
+++ b/include/goofit/PDFs/physics/DalitzPlotHelpers.h
@@ -22,7 +22,7 @@ constexpr typename std::underlying_type<E>::type enum_to_underlying(E e) {
     return static_cast<typename std::underlying_type<E>::type>(e);
 }
 
-__device__ bool inDalitz(
+__host__ __device__ bool inDalitz(
     const fptype &m12, const fptype &m13, const fptype &bigM, const fptype &dm1, const fptype &dm2, const fptype &dm3);
 
 __device__ fpcomplex

--- a/include/goofit/PDFs/physics/DalitzPlotPdf.h
+++ b/include/goofit/PDFs/physics/DalitzPlotPdf.h
@@ -9,6 +9,7 @@ namespace GooFit {
 
 class SpecialResonanceIntegrator;
 class SpecialResonanceCalculator;
+class DalitzPlotter;
 
 class DalitzPlotPdf : public GooPdf {
   public:
@@ -26,11 +27,13 @@ class DalitzPlotPdf : public GooPdf {
     __host__ void setDataSize(unsigned int dataSize, unsigned int evtSize = 3);
     __host__ void setForceIntegrals(bool f = true) { forceRedoIntegrals = f; }
 
+    friend DalitzPlotter;
+
   protected:
-  private:
     DecayInfo3 decayInfo;
     Observable _m12;
     Observable _m13;
+    EventNumber _eventNumber;
     fptype *dalitzNormRange;
 
     // Following variables are useful if masses and widths, involved in difficult BW calculation,

--- a/include/goofit/PDFs/physics/DalitzPlotter.h
+++ b/include/goofit/PDFs/physics/DalitzPlotter.h
@@ -1,0 +1,93 @@
+/*
+04/05/2016 Christoph Hasse
+DISCLAIMER:
+
+This code is not sufficently tested yet and still under heavy development!
+See *.cu file for more details
+*/
+
+#pragma once
+
+#include <goofit/PDFs/GooPdf.h>
+#include <goofit/PDFs/physics/DalitzPlotHelpers.h>
+#include <goofit/PDFs/physics/DalitzPlotPdf.h>
+
+
+namespace GooFit {
+
+
+/// This class makes it easy to make plots over 3 body Dalitz PDFs. You can use ROOT style value access or bin numbers.
+class DalitzPlotter {
+    std::vector<size_t> xbins;
+    std::vector<size_t> ybins;
+    std::vector<std::vector<fptype>> pdfValues;
+    Observable m12;
+    Observable m13;
+    EventNumber eventNumber;
+    UnbinnedDataSet data;
+    fptype mother;
+    
+
+public:
+    DalitzPlotter(GooPdf* overallSignal, DalitzPlotPdf* signalDalitz)
+        : m12(signalDalitz->_m12), m13(signalDalitz->_m13), eventNumber(signalDalitz->_eventNumber), data({m12, m13, eventNumber}), mother(signalDalitz->decayInfo.motherMass){
+
+        eventNumber.setValue(0);
+        for (size_t i = 0; i < m12.getNumBins(); ++i) {
+            m12.setValue(m12.getLowerLimit() + (m12.getUpperLimit() - m12.getLowerLimit())*(i + 0.5) / m12.getNumBins());
+            for (size_t j = 0; j < m13.getNumBins(); ++j) {
+                m13.setValue(m13.getLowerLimit() + (m13.getUpperLimit() - m13.getLowerLimit())*(j + 0.5) / m13.getNumBins());
+                if(inDalitz(m12.getValue(),
+                            m13.getValue(),
+                            signalDalitz->decayInfo.motherMass,
+                            signalDalitz->decayInfo.daug1Mass,
+                            signalDalitz->decayInfo.daug2Mass,
+                            signalDalitz->decayInfo.daug3Mass)) {
+                    xbins.push_back(m12.getValue());
+                    ybins.push_back(m13.getValue());
+                    data.addEvent();
+                    eventNumber.setValue(eventNumber.getValue() + 1);
+                }
+            }
+        }
+
+        overallSignal->setData(&data);
+        signalDalitz->setDataSize(data.getNumEvents());
+
+        pdfValues = overallSignal->getCompProbsAtDataPoints();
+    }
+
+    size_t getNumEvents() const {
+        return data.getNumEvents();
+    }
+
+    size_t getX(size_t event) const {
+        return xbins.at(event);
+    }
+
+    size_t getY(size_t event) const {
+        return ybins.at(event);
+    }
+
+    fptype getXval(size_t event) const {
+        return data.getValue(m12, event);
+    }
+
+    fptype getYval(size_t event) const {
+        return data.getValue(m13, event);
+    }
+
+    fptype getZval(size_t event) const {
+        return POW2(mother) - POW2(getXval(event)) - POW2(getYval(event));
+    }
+
+    fptype getVal(size_t event, size_t num=0) const {
+        return pdfValues.at(num).at(event);
+    }
+
+    UnbinnedDataSet* getDataSet() {
+        return &data;
+    }
+};
+
+} // namespace GooFit

--- a/include/goofit/PDFs/physics/DalitzPlotter.h
+++ b/include/goofit/PDFs/physics/DalitzPlotter.h
@@ -1,17 +1,13 @@
-/*
-04/05/2016 Christoph Hasse
-DISCLAIMER:
-
-This code is not sufficently tested yet and still under heavy development!
-See *.cu file for more details
-*/
-
 #pragma once
 
+#include <goofit/Version.h>
 #include <goofit/PDFs/GooPdf.h>
 #include <goofit/PDFs/physics/DalitzPlotHelpers.h>
 #include <goofit/PDFs/physics/DalitzPlotPdf.h>
 
+#if GOOFIT_ROOT_FOUND
+#include <TH2.h>
+#endif
 
 namespace GooFit {
 
@@ -43,8 +39,8 @@ public:
                             signalDalitz->decayInfo.daug1Mass,
                             signalDalitz->decayInfo.daug2Mass,
                             signalDalitz->decayInfo.daug3Mass)) {
-                    xbins.push_back(m12.getValue());
-                    ybins.push_back(m13.getValue());
+                    xbins.push_back(i);
+                    ybins.push_back(j);
                     data.addEvent();
                     eventNumber.setValue(eventNumber.getValue() + 1);
                 }
@@ -88,6 +84,33 @@ public:
     UnbinnedDataSet* getDataSet() {
         return &data;
     }
+
+#if GOOFIT_ROOT_FOUND
+    TH2F* make2D(std::string name="dalitzplot", std::string title="") {
+       TH2F* dalitzplot = new TH2F(
+               name.c_str(),
+               title.c_str(),
+               m12.getNumBins(),
+               m12.getLowerLimit(),
+               m12.getUpperLimit(),
+               m13.getNumBins(),
+               m13.getLowerLimit(),
+               m13.getUpperLimit()
+            );
+
+    
+        for (unsigned int j = 0; j < getNumEvents(); ++j) {
+            size_t currm12 = getX(j);
+            size_t currm13 = getY(j);
+            double val = getVal(j);
+
+            dalitzplot->SetBinContent(1+currm12, 1+currm13, val);
+        }
+    
+    return dalitzplot;
+ 
+    }
+#endif
 };
 
 } // namespace GooFit

--- a/include/goofit/PDFs/physics/DalitzPlotter.h
+++ b/include/goofit/PDFs/physics/DalitzPlotter.h
@@ -130,6 +130,9 @@ class DalitzPlotter {
 
     UnbinnedDataSet *getDataSet() { return &data; }
 
+    const Observable &getM12() const { return m12; }
+    const Observable &getM13() const { return m13; }
+
 #if GOOFIT_ROOT_FOUND
     /// Produce a TH2F over the contained evaluation
     TH2F *make2D(std::string name = "dalitzplot", std::string title = "") {

--- a/include/goofit/detail/Style.h
+++ b/include/goofit/detail/Style.h
@@ -1,15 +1,14 @@
-#pragma once 
+#pragma once
 
 #include <goofit/Version.h>
 
 #if GOOFIT_ROOT_FOUND
 
-#include <TCanvas.h>
 #include <RVersion.h>
+#include <TCanvas.h>
 #include <TStyle.h>
 
 #endif
-
 
 namespace GooFit {
 
@@ -38,6 +37,5 @@ void setROOTStyle() {
 }
 
 #endif
-
 
 } // namepspace GooFit

--- a/include/goofit/detail/Style.h
+++ b/include/goofit/detail/Style.h
@@ -1,0 +1,43 @@
+#pragma once 
+
+#include <goofit/Version.h>
+
+#if GOOFIT_ROOT_FOUND
+
+#include <TCanvas.h>
+#include <RVersion.h>
+#include <TStyle.h>
+
+#endif
+
+
+namespace GooFit {
+
+#if GOOFIT_ROOT_FOUND
+
+/// A default set of ROOT styles for pretty GooFit plots
+void setROOTStyle() {
+    gStyle->SetCanvasBorderMode(0);
+    gStyle->SetCanvasColor(10);
+    gStyle->SetFrameFillColor(10);
+    gStyle->SetFrameBorderMode(0);
+    gStyle->SetPadColor(0);
+    gStyle->SetTitleColor(1);
+    gStyle->SetStatColor(0);
+    gStyle->SetFillColor(0);
+    gStyle->SetFuncWidth(1);
+    gStyle->SetLineWidth(1);
+    gStyle->SetLineColor(1);
+    gStyle->SetNumberContours(256);
+    gStyle->SetOptStat(0);
+
+    if(ROOT_VERSION_CODE < ROOT_VERSION(6, 6, 0))
+        gStyle->SetPalette(kRainBow, 0);
+    else
+        gStyle->SetPalette(kViridis, 0);
+}
+
+#endif
+
+
+} // namepspace GooFit

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -61,6 +61,7 @@ goofit_add_library(_goofit MODULE
     PDFs/physics/DalitzPlotPdf.cu
     PDFs/physics/DalitzVetoPdf.cu
     PDFs/physics/DalitzPlotHelpers.cu
+    PDFs/physics/DalitzPlotter.cu
     PDFs/physics/DP4Pdf.cu
     PDFs/physics/IncoherentSumPdf.cu
     PDFs/physics/LineshapesPdf.cu

--- a/python/PDFs/physics/DalitzPlotter.cu
+++ b/python/PDFs/physics/DalitzPlotter.cu
@@ -1,0 +1,19 @@
+#include <goofit/PDFs/physics/DalitzPlotter.h>
+#include <pybind11/pybind11.h>
+
+using namespace GooFit;
+namespace py = pybind11;
+using namespace pybind11::literals;
+
+void init_DalitzPlotter(py::module &m) {
+    py::class_<DalitzPlotter>(m, "DalitzPlotter")
+        .def(py::init<GooPdf *, DalitzPlotPdf *>())
+        .def("getNumEvents", &DalitzPlotter::getNumEvents)
+        .def("getX", &DalitzPlotter::getX, "event"_a)
+        .def("getY", &DalitzPlotter::getY, "event"_a)
+        .def("getXval", &DalitzPlotter::getXval, "event"_a)
+        .def("getYval", &DalitzPlotter::getYval, "event"_a)
+        .def("getZval", &DalitzPlotter::getZval, "event"_a)
+        .def("getVal", &DalitzPlotter::getVal, "event"_a, "num"_a = 0)
+        .def("getDataSet", &DalitzPlotter::getDataSet);
+}

--- a/python/examples/addition.py
+++ b/python/examples/addition.py
@@ -5,6 +5,8 @@ from __future__ import print_function, division
 
 from goofit import *
 import numpy as np
+import matplotlib
+matplotlib.use('Agg')
 import matplotlib.pyplot as plt
 
 print_goofit_info()

--- a/python/examples/addition.py
+++ b/python/examples/addition.py
@@ -5,45 +5,57 @@ from __future__ import print_function, division
 
 from goofit import *
 import numpy as np
+import matplotlib.pyplot as plt
 
 print_goofit_info()
 
 xvar = Observable("xvar", -5, 5)
-
 data = UnbinnedDataSet(xvar)
 
-totalData = 0
+# Classic C++ style method:
+#i = 0
+#while i < 100000:
+#    xvar.value = np.random.normal(0.2,1.1)
+#
+#    if np.random.uniform() < 0.1:
+#        xvar.value = np.random.uniform(-5,5)
+#
+#    if abs(xvar.value) <= 5:
+#        data.addEvent()
+#        i += 1
+# dat = data.to_matrix().flatten()
 
-
-i=-1
-
-while i < 100000:
-    i+=1
-    xvar.value = np.random.normal(0.2,1.1)
-
-    if np.random.uniform() < 0.1:
-        xvar.value = np.random.uniform(-5,5)
-
-
-    if abs(xvar.value) > 5:
-        i-=1
-        continue
-
-    data.addEvent()
+# Better method in Python:
+dat = np.random.normal(0.2,1.1,100000)
+dat[:10000] = np.random.uniform(-5,5,10000)
+data.from_matrix([dat], filter=True)
 
 
 xmean = Variable("xmean", 0, 1, -10, 10)
 xsigm = Variable("xsigm", 1, 0.5, 1.5)
 signal = GaussianPdf("signal", xvar, xmean, xsigm)
 
+constant = Variable("constant", 1.0)
+backgr = PolynomialPdf("backgr", xvar, [constant])
 
-constant = [Variable("constant", 1.0)]
-backgr = PolynomialPdf("backgr", xvar, constant)
+sigfrac = Variable("sigFrac", 0.9, 0.75, 1.00)
 
-sigFrac = Variable("sigFrac", 0.9, 0.75, 1.00)
+total = AddPdf("total", [sigfrac], [signal, backgr])
+total.fitTo(data)
 
-total = AddPdf("total", [sigFrac], [signal,backgr])
-total.setData(data)
+# Plot data
+plt.hist(dat, bins='auto', label='data', normed=True)
 
-fitter = FitManager(total)
-fitter.fit()
+# Make grid and evaluate on it
+grid = total.makeGrid()
+total.setData(grid)
+main, gauss, flat = total.getCompProbsAtDataPoints()
+xvals = grid.to_matrix().flatten()
+
+plt.plot(xvals, main, label='total')
+plt.plot(xvals, np.array(gauss)*sigfrac.value, label='signal')
+plt.plot(xvals, np.array(flat)*(1-sigfrac.value), label='background')
+
+plt.legend()
+plt.savefig('addition_plot.pdf')
+#plt.show()

--- a/python/examples/dalitz.py
+++ b/python/examples/dalitz.py
@@ -46,8 +46,8 @@ def getToyData(toyFileName):
     # Add figure/subplot
     fig, ax = plt.subplots()
     ax.hist2d(out.m12, out.m13, bins=[100,100])
-    fig.savefig("dalitzplot.png")
-    print("Original data plot:", "dalitzplot.png")
+    fig.savefig("dalitz_data_plot.png")
+    print("Original data plot:", "dalitz_data_plot.png")
 
     return m12, m13, eventNumber, data
 
@@ -243,18 +243,20 @@ def runToyFit(toyFileName):
 def main():
     filename = GOOFIT_SOURCE_DIR + "/examples/dalitz/dalitz_toyMC_000.txt"
     fitman, signal, m12, m23 =  runToyFit(filename)
-    
-    # Make a grid and evaluate over it
-    grid = signal.makeGrid()
-    signal.setData(grid)
-    # Segfault here:
-    #val = signal.getCompProbsAtDataPoints()
-    
-    
-    #for i in range(len(grid)):
-    #    grid.loadEvent(i)
-    #    print(m12, m13, val[0][i])
-    
+
+    # A wrapper to avoid segfaulting when accessing a complex component
+    prodpdf = ProdPdf("prodpdf", [signal])
+
+    # Add nice tool for making data or plotting
+    dplotter = DalitzPlotter(prodpdf, signal)
+
+    arr = dplotter.make2D()
+    extent = dplotter.getExtent()
+    plt.imshow(arr, extent=extent, origin='lower')
+
+    plt.savefig("dalitz_pdf_plot.png")
+    print("Fit PDF plot:", "dalitz_pdf_plot.png")
+
     # Double int's needed here since int may return a long and sys.exit needs a real int for Python2
     return int(int(fitman))
 

--- a/python/goofit.cpp
+++ b/python/goofit.cpp
@@ -48,6 +48,7 @@ void init_ProdPdf(py::module &);
 // Physics
 void init_DalitzPlotHelpers(py::module &);
 void init_DalitzPlotPdf(py::module &);
+void init_DalitzPlotter(py::module &);
 void init_DalitzVetoPdf(py::module &);
 void init_DP4Pdf(py::module &);
 void init_IncoherentSumPdf(py::module &);

--- a/python/goofit.cpp
+++ b/python/goofit.cpp
@@ -112,6 +112,7 @@ PYBIND11_MODULE(_goofit, m) {
 
     // Physics
     init_DalitzPlotHelpers(m);
+    init_DalitzPlotter(m);
     init_DalitzPlotPdf(m);
     init_DalitzVetoPdf(m);
     init_DP4Pdf(m);

--- a/setup.py
+++ b/setup.py
@@ -7,13 +7,30 @@ except ImportError:
 
 setup(
         name='goofit',
-        version='2.1.0',
+        version='2.1.1',
         description='GooFit fitting package',
         author='Henry Schreiner',
         author_email='hschrein@cern.ch',
         url='https://goofit.github.io',
         platforms = ["POSIX"],
         provides = ["goofit"],
+        classifiers = [
+            "Development Status :: 5 - Production/Stable",
+            "Intended Audience :: Science/Research",
+            "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
+            "Natural Language :: English",
+            "Operating System :: Unix",
+            "Programming Language :: C++",
+            "Programming Language :: Python",
+            "Programming Language :: Python :: 2",
+            "Programming Language :: Python :: 2.7",
+            "Programming Language :: Python :: 3",
+            "Programming Language :: Python :: 3.4",
+            "Programming Language :: Python :: 3.5",
+            "Programming Language :: Python :: 3.6",
+            "Programming Language :: Python :: 3.7",
+            "Topic :: Scientific/Engineering :: Physics"
+        ]
         cmake_args=[
             '-DGOOFIT_PYTHON=ON',
             '-DGOOFIT_EXAMPLES=OFF'],
@@ -88,7 +105,7 @@ Local Pipenv
 
 Or, if you use pipenv::
 
-    pipenv install --verbose -e . --skip-lock
+    pipenv install --verbose --dev
 
 And, to use::
 
@@ -98,7 +115,6 @@ You can set the ``PIP_INSTALL_OPTIONS`` variable to pass through build command, 
 
     PIP_INSTALL_OPTIONS="-- -DGOOFIT_PACKAGES=OFF" pipenv install --verbose -e .
 
-You can also install development requirements with the ``--dev`` flag. Note that the current version of PyLandau requires numpy tp be installed first, so you might need to run ``pipenv install numpy`` first.
 
 Building a source package from git
 ==================================

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,11 @@ Traditional pip install::
     pip install -v goofit
 
 
+If you want to send commands to CMake through PIP, use (for example)::
+
+    PIP_INSTALL_OPTIONS="-- -DGOOFIT_PACKAGES=OFF" pip install -v goofit
+
+
 Installation: local
 ===================
 

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
             "Programming Language :: Python :: 3.6",
             "Programming Language :: Python :: 3.7",
             "Topic :: Scientific/Engineering :: Physics"
-        ]
+        ],
         cmake_args=[
             '-DGOOFIT_PYTHON=ON',
             '-DGOOFIT_EXAMPLES=OFF'],
@@ -56,20 +56,6 @@ Installation basics
 This package can be installed with pip, but uses SciKit-Build, and is build, fully optimized, on your system. Because of this, there are a few caveats when running a pip install. Make sure you have SciKit-Build (``pip install scikit-build``) before you attempt an install. Also, if you don't have a recent version of CMake (3.8 or better recommended), also run ``pip install cmake``. When you build, you should also use pip's ``-v`` flag, so that you can see it build (and observe the
 configuration options). Otherwise, you might wait a very long time without output (especially if CUDA was found).
 
-Installation: pipenv
-====================
-
-Use pipenv, the officially recommended method for managing installs, virtual environments, and dependencies.
-
-To install::
-
-    pipenv install scikit-build cmake
-    pipenv install --verbose goofit
-
-To run a shell::
-
-    pipenv shell
-
 
 Installation: pip
 =================
@@ -93,27 +79,28 @@ If you want to add PDFs to GooFit, or use GooFit pacakges, you should be working
     git clone --recursive git@github.com:GooFit/GooFit.git
     cd goofit
 
-Local Pip
-~~~~~~~~~
+Pipenv
+~~~~~~
 
-If you use pip::
+You can set up a quick environment using pipenv::
 
-    pip install -v -e .
+    pipenv install --dev
 
-Local Pipenv
-~~~~~~~~~~~~
-
-Or, if you use pipenv::
-
-    pipenv install --verbose --dev
-
-And, to use::
+Then activate that environment::
 
     pipenv shell
 
+Local pip
+~~~~~~~~~
+
+The normal install here works, though as usual you should include verbose output::
+
+    pip install -v .
+
+
 You can set the ``PIP_INSTALL_OPTIONS`` variable to pass through build command, for example::
 
-    PIP_INSTALL_OPTIONS="-- -DGOOFIT_PACKAGES=OFF" pipenv install --verbose -e .
+    PIP_INSTALL_OPTIONS="-- -DGOOFIT_PACKAGES=OFF" pip install -v .
 
 
 Building a source package from git

--- a/src/PDFs/CMakeLists.txt
+++ b/src/PDFs/CMakeLists.txt
@@ -36,6 +36,7 @@ set(GOOPDF_HEADERS
     ${PROJECT_SOURCE_DIR}/include/goofit/PDFs/combine/CompositePdf.h
     ${PROJECT_SOURCE_DIR}/include/goofit/PDFs/combine/ConvolutionPdf.h
     ${PROJECT_SOURCE_DIR}/include/goofit/PDFs/physics/DalitzPlotHelpers.h
+    ${PROJECT_SOURCE_DIR}/include/goofit/PDFs/physics/DalitzPlotter.h
     ${PROJECT_SOURCE_DIR}/include/goofit/PDFs/physics/SpinFactors.h
     ${PROJECT_SOURCE_DIR}/include/goofit/PDFs/physics/MixingTimeResolution_Aux.h
     ${PROJECT_SOURCE_DIR}/include/goofit/PDFs/physics/TruthResolution_Aux.h

--- a/src/PDFs/physics/DalitzPlotHelpers.cu
+++ b/src/PDFs/physics/DalitzPlotHelpers.cu
@@ -10,6 +10,47 @@ Helper functions
 
 namespace GooFit {
 
+__host__ __device__ bool inDalitz(
+    const fptype &m12, const fptype &m13, const fptype &bigM, const fptype &dm1, const fptype &dm2, const fptype &dm3) {
+    fptype dm1pdm2  = dm1 + dm2;
+    fptype bigMmdm3 = bigM - dm3;
+
+    bool m12less = (m12 < dm1pdm2 * dm1pdm2) ? false : true;
+    // if (m12 < dm1pdm2*dm1pdm2) return false; // This m12 cannot exist, it's less than the square of the (1,2)
+    // particle mass.
+    bool m12grea = (m12 > bigMmdm3 * bigMmdm3) ? false : true;
+    // if (m12 > bigMmdm3*bigMmdm3) return false;   // This doesn't work either, there's no room for an at-rest 3
+    // daughter.
+
+    fptype sqrtM12 = sqrt(m12);
+    fptype dm11    = dm1 * dm1;
+    fptype dm22    = dm2 * dm2;
+    fptype dm33    = dm3 * dm3;
+
+    // Calculate energies of 1 and 3 particles in m12 rest frame.
+    // fptype e1star = 0.5 * (m12 - dm2*dm2 + dm1*dm1) / sqrt(m12);
+    fptype e1star = 0.5 * (m12 - dm22 + dm11) / sqrtM12;
+    // fptype e3star = 0.5 * (bigM*bigM - m12 - dm3*dm3) / sqrt(m12);
+    fptype e3star = 0.5 * (bigM * bigM - m12 - dm33) / sqrtM12;
+
+    fptype rte1mdm11 = sqrt(e1star * e1star - dm11);
+    fptype rte3mdm33 = sqrt(e3star * e3star - dm33);
+
+    // Bounds for m13 at this value of m12.
+    // fptype minimum = (e1star + e3star)*(e1star + e3star) - pow(sqrt(e1star1 - dm11) + sqrt(e3star*e3star - dm33), 2);
+    fptype minimum = (e1star + e3star) * (e1star + e3star) - (rte1mdm11 + rte3mdm33) * (rte1mdm11 + rte3mdm33);
+
+    bool m13less = (m13 < minimum) ? false : true;
+    // if (m13 < minimum) return false;
+
+    // fptype maximum = pow(e1star + e3star, 2) - pow(sqrt(e1star*e1star - dm1*dm1) - sqrt(e3star*e3star - dm3*dm3), 2);
+    fptype maximum = (e1star + e3star) * (e1star + e3star) - (rte1mdm11 - rte3mdm33) * (rte1mdm11 - rte3mdm33);
+    bool m13grea   = (m13 > maximum) ? false : true;
+    // if (m13 > maximum) return false;
+
+    return m12less && m12grea && m13less && m13grea;
+}
+
 __device__ fptype Mass(const fptype *P0) {
     return sqrt(-P0[0] * P0[0] - P0[1] * P0[1] - P0[2] * P0[2] + P0[3] * P0[3]);
 }

--- a/src/PDFs/physics/DalitzPlotPdf.cu
+++ b/src/PDFs/physics/DalitzPlotPdf.cu
@@ -111,6 +111,7 @@ __host__ DalitzPlotPdf::DalitzPlotPdf(
     , decayInfo(decay)
     , _m12(m12)
     , _m13(m13)
+    , _eventNumber(eventNumber)
     , dalitzNormRange(nullptr)
     //, cachedWaves(0)
     , integrals(nullptr)

--- a/src/PDFs/physics/TddpPdf.cu
+++ b/src/PDFs/physics/TddpPdf.cu
@@ -24,68 +24,6 @@ const unsigned int SPECIAL_RESOLUTION_FLAG = 999999999;
 // NOTE: only one set of wave holders is supported currently.
 __device__ WaveHolder_s *cWaves[16];
 
-/*
-__device__ bool inDalitz (const fptype &m12, const fptype &m13, const fptype &bigM, const fptype &dm1, const fptype
-&dm2, const fptype &dm3) {
-  if (m12 < pow(dm1 + dm2, 2)) return false; // This m12 cannot exist, it's less than the square of the (1,2) particle
-mass.
-  if (m12 > pow(bigM - dm3, 2)) return false;   // This doesn't work either, there's no room for an at-rest 3 daughter.
-
-  // Calculate energies of 1 and 3 particles in m12 rest frame.
-  fptype e1star = 0.5 * (m12 - dm2*dm2 + dm1*dm1) / sqrt(m12);
-  fptype e3star = 0.5 * (bigM*bigM - m12 - dm3*dm3) / sqrt(m12);
-
-  // Bounds for m13 at this value of m12.
-  fptype minimum = pow(e1star + e3star, 2) - pow(sqrt(e1star*e1star - dm1*dm1) + sqrt(e3star*e3star - dm3*dm3), 2);
-  if (m13 < minimum) return false;
-  fptype maximum = pow(e1star + e3star, 2) - pow(sqrt(e1star*e1star - dm1*dm1) - sqrt(e3star*e3star - dm3*dm3), 2);
-  if (m13 > maximum) return false;
-
-  return true;
-}
-*/
-
-__device__ bool inDalitz(
-    const fptype &m12, const fptype &m13, const fptype &bigM, const fptype &dm1, const fptype &dm2, const fptype &dm3) {
-    fptype dm1pdm2  = dm1 + dm2;
-    fptype bigMmdm3 = bigM - dm3;
-
-    bool m12less = (m12 < dm1pdm2 * dm1pdm2) ? false : true;
-    // if (m12 < dm1pdm2*dm1pdm2) return false; // This m12 cannot exist, it's less than the square of the (1,2)
-    // particle mass.
-    bool m12grea = (m12 > bigMmdm3 * bigMmdm3) ? false : true;
-    // if (m12 > bigMmdm3*bigMmdm3) return false;   // This doesn't work either, there's no room for an at-rest 3
-    // daughter.
-
-    fptype sqrtM12 = sqrt(m12);
-    fptype dm11    = dm1 * dm1;
-    fptype dm22    = dm2 * dm2;
-    fptype dm33    = dm3 * dm3;
-
-    // Calculate energies of 1 and 3 particles in m12 rest frame.
-    // fptype e1star = 0.5 * (m12 - dm2*dm2 + dm1*dm1) / sqrt(m12);
-    fptype e1star = 0.5 * (m12 - dm22 + dm11) / sqrtM12;
-    // fptype e3star = 0.5 * (bigM*bigM - m12 - dm3*dm3) / sqrt(m12);
-    fptype e3star = 0.5 * (bigM * bigM - m12 - dm33) / sqrtM12;
-
-    fptype rte1mdm11 = sqrt(e1star * e1star - dm11);
-    fptype rte3mdm33 = sqrt(e3star * e3star - dm33);
-
-    // Bounds for m13 at this value of m12.
-    // fptype minimum = (e1star + e3star)*(e1star + e3star) - pow(sqrt(e1star1 - dm11) + sqrt(e3star*e3star - dm33), 2);
-    fptype minimum = (e1star + e3star) * (e1star + e3star) - (rte1mdm11 + rte3mdm33) * (rte1mdm11 + rte3mdm33);
-
-    bool m13less = (m13 < minimum) ? false : true;
-    // if (m13 < minimum) return false;
-
-    // fptype maximum = pow(e1star + e3star, 2) - pow(sqrt(e1star*e1star - dm1*dm1) - sqrt(e3star*e3star - dm3*dm3), 2);
-    fptype maximum = (e1star + e3star) * (e1star + e3star) - (rte1mdm11 - rte3mdm33) * (rte1mdm11 - rte3mdm33);
-    bool m13grea   = (m13 > maximum) ? false : true;
-    // if (m13 > maximum) return false;
-
-    return m12less && m12grea && m13less && m13grea;
-}
-
 __device__ inline int parIndexFromResIndex(int resIndex) { return resonanceOffset + resIndex * resonanceSize; }
 
 __device__ fpcomplex

--- a/src/goofit/CMakeLists.txt
+++ b/src/goofit/CMakeLists.txt
@@ -51,6 +51,7 @@ goofit_add_library(PdfBase
     ${PROJECT_BINARY_DIR}/include/goofit/detail/ThrustOverrideConfig.h
     ${PROJECT_BINARY_DIR}/include/goofit/detail/Backtrace.h
     ${PROJECT_SOURCE_DIR}/include/goofit/detail/Macros.h
+    ${PROJECT_SOURCE_DIR}/include/goofit/detail/Style.h
     ${PROJECT_SOURCE_DIR}/include/goofit/Error.h
     ${PROJECT_SOURCE_DIR}/include/goofit/PdfBase.h
     ${PROJECT_SOURCE_DIR}/include/goofit/FitControl.h


### PR DESCRIPTION
This adds a few fixes and a nice Dalitz plotter interface.

* FeatureDetector works correctly again (regression: it was no longer detecting compiling options)
* Better notes in README about ROOT and CUDA versions
* The GooFit style is set in `GooFit::setROOTStyle()`
* Added `DalitzPlotter`, which helps in making plots of 3-body Dalitz PDFs and toy generation.
* Cleaned up Dalitz example, adding more plotting
* Some Python improvements to `addition.py` and `dalitz.py`
* in Dalitz functions cleaned up and generally available for use in `DalitzPlotHelpers`
* ROOT missing variable improved.