### PR TITLE
Adding _Aux redirects

### DIFF
--- a/include/goofit/PDFs/physics/ThreeGaussResolution_Aux.h
+++ b/include/goofit/PDFs/physics/ThreeGaussResolution_Aux.h
@@ -1,0 +1,3 @@
+#pragma once
+
+#include <goofit/PDFs/physics/ThreeGaussResolution.h>

--- a/include/goofit/PDFs/physics/TruthResolution_Aux.h
+++ b/include/goofit/PDFs/physics/TruthResolution_Aux.h
@@ -1,0 +1,3 @@
+#pragma once
+
+#include <goofit/PDFs/physics/TruthResolution.h>


### PR DESCRIPTION
This allows `*Resolution_Aux.h` includes to work for now (deprecated).