### PR TITLE
Colorama is getting imported, and is a very old version with no __version__

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,8 +39,8 @@ matrix:
         - python-pip
     install:
     - python -m pip install --user --upgrade pip
-    - python -m pip install --user scikit-build pytest numpy plumbum pandas matplotlib numba twine
-      uncertainties
+    - python -m pip install --user --upgrade colorama # Required for numba due to a bug
+    - python -m pip install --user plumbum pandas matplotlib numba uncertainties scikit-build pytest numpy twine
     - source .ci/build_doxygen.sh
     script:
     - if [[ -n "${TRAVIS_TAG}" ]] ; then python setup.py sdist && python -m twine upload dist/* ; fi


### PR DESCRIPTION
This forcibly installs a local, upgraded colorama. PR made to Numba as well, numba/numba#3384, but this will fix it for now for us.