### PR TITLE
Submodules of submodules are not needed 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,7 +45,7 @@ if(GIT_FOUND AND EXISTS "${GOOFIT_SOURCE_DIR}/.git")
     option(GOOFIT_SUBMODULE "Check submodules during build" ON)
     if(GOOFIT_SUBMODULE)
         message(STATUS "Submodule update")
-        execute_process(COMMAND ${GIT_EXECUTABLE} submodule update --init --recursive
+        execute_process(COMMAND ${GIT_EXECUTABLE} submodule update --init
             WORKING_DIRECTORY ${GOOFIT_SOURCE_DIR}
             RESULT_VARIABLE GIT_SUBMOD_RESULT)
         if(NOT GIT_SUBMOD_RESULT EQUAL "0")


### PR DESCRIPTION
And PyBind11 can break with no https support (fix in latest master, pybind/pybind11#1563), but I need to check to see if CUDA support is still broken in PyBind11 > 2.2.2.