### PR TITLE
WIP: Small fixes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,2 @@
 [build-system]
-requires = ["setuptools", "wheel", "scikit-build"]
+requires = ["setuptools", "wheel", "scikit-build==0.6.1"]

--- a/python/PDFs/physics/ResonancePdf.cpp
+++ b/python/PDFs/physics/ResonancePdf.cpp
@@ -1,5 +1,7 @@
 #include <goofit/Python.h>
 
+#include <pybind11/stl.h>
+
 #include <goofit/PDFs/physics/ResonancePdf.h>
 #include <goofit/Variable.h>
 #include <goofit/docs/PDFs/physics/resonances/Resonance.h>
@@ -7,8 +9,6 @@
 using namespace GooFit;
 
 void init_ResonancePdf(py::module &m) {
-    // m.attr("MAXNKNOBS") = MAXNKNOBS;
-
     auto m_ls = m.def_submodule("Resonances");
 
     py::class_<ResonancePdf, GooPdf>(m, "ResonancePdf").def_static("help", []() {

--- a/setup.py
+++ b/setup.py
@@ -76,9 +76,9 @@ Using pip < 10::
     pip install -v goofit
 
 
-If you want to send commands to CMake through PIP, you will need to pass each option through, starting with a ``--`` option. Pip will try to reuse the built version, so adding ``--no-cache-dir`` will ensure your options are used. For example, if you are on Anaconda and realize that GooFit and Anaconda are using different OpenMP libraries::
+If you want to send commands to CMake through PIP, you will need to pass each option through, starting with a ``--`` option. Pip will try to reuse the built version if you do not pass options, but will rebuild if you pass options. For example, if you are on Anaconda and realize that GooFit and Anaconda are using different OpenMP libraries::
 
-    pip install -v goofit --no-cache-dir --install-option="--" --install-option="-DGOOFIT_DEVICE=CPP"
+    pip install -v goofit --install-option="--" --install-option="-DGOOFIT_DEVICE=CPP"
 
 
 Installation: local
@@ -108,9 +108,9 @@ The normal install here works, though as usual you should include verbose output
     pip install -v .
 
 
-You can set the ``PIP_INSTALL_OPTIONS`` variable to pass through build command, for example::
+You can pass through options to the build command, for example::
 
-    PIP_INSTALL_OPTIONS="-- -DGOOFIT_PACKAGES=OFF" pip install -v .
+    pip install -v . --install-options="--" --install-options="-DGOOFIT_PACKAGES=OFF"
 
 
 Building a source package from git

--- a/src/PDFs/combine/CompositePdf.cu
+++ b/src/PDFs/combine/CompositePdf.cu
@@ -29,7 +29,7 @@ __device__ fptype device_Composite(fptype *evt, ParameterContainer &pc) {
     // fptype ret = (*(reinterpret_cast<device_function_ptr>(d_function_table[shellFcnIndex])))(fakeEvt, cudaArray,
     // shellParams);
     fptype ret = callFunction(fakeEvt, pc);
-    delete fakeEvt;
+    delete[] fakeEvt;
 
     // if (0 == THREADIDX)
     // printf("Composite: %f %f %f %f %f %f\n", evt[4], evt[5], evt[6], evt[7], coreValue, ret);

--- a/src/PDFs/physics/resonances/Spline.cu
+++ b/src/PDFs/physics/resonances/Spline.cu
@@ -127,7 +127,6 @@ __host__ void Spline::recalculateCache() const {
             y[idx].imag(value);
     }
 
-    printf("%i %i\n", x.size(), y.size());
     std::vector<fptype> y2_flat = flatten(complex_derivative(x, y));
 
     MEMCPY_TO_SYMBOL(cDeriatives, y2_flat.data(), 2 * nKnobs * sizeof(fptype), 0, cudaMemcpyHostToDevice);


### PR DESCRIPTION
Preparing for a 2.2.1 release. Fixing smaller bugs, like some warnings, a missing header that kept Splines from being used by Python, and pinning an older Scikit-build version for now (0.7+ buggy on macOS).