### PR TITLE
CrystallBallPdf Parameter Registration Fix

### DIFF
--- a/src/PDFs/basic/CrystalBallPdf.cu
+++ b/src/PDFs/basic/CrystalBallPdf.cu
@@ -11,10 +11,10 @@ __device__ fptype device_CrystalBall(fptype *evt, ParameterContainer &pc) {
     int id = pc.getObservable(0);
 
     fptype x     = RO_CACHE(evt[id]);
-    fptype mean  = pc.getParameter(1);
-    fptype sigma = pc.getParameter(2);
-    fptype alpha = pc.getParameter(3);
-    fptype power = pc.getParameter(4);
+    fptype mean  = pc.getParameter(0);
+    fptype sigma = pc.getParameter(1);
+    fptype alpha = pc.getParameter(2);
+    fptype power = pc.getParameter(3);
     fptype rx    = (sigma != 0) ? (x - mean) / sigma : 0;
     fptype ret   = 0;
 


### PR DESCRIPTION
The p.d.f. is not working since parameters are registered from 1 to 4 and not to 0 to 3 as it should be. Now seems to be smooth.