### PR TITLE
chore: bump to scikit-build 0.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         submodules: recursive
 
     - name: Configure
-      run: cmake -S . -B build -DGOOFIT_DEVICE=OMP -DGOOFIT_CXX_STANDARD=11
+      run: cmake -S . -B build -DGOOFIT_DEVICE=OMP -DGOOFIT_CXX_STANDARD=17
     - name: Build
       run: cmake --build build -j "$(getconf _NPROCESSORS_ONLN)"
     - name: Run Tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,9 @@
 [build-system]
 requires = [
-    "setuptools>=42", "wheel", "scikit-build>0.10", "cmake>=3.20", "ninja>=1.9"
+    "setuptools>=42",
+    "wheel",
+    "scikit-build>=0.12",
+    "cmake>=3.20",
+    "ninja>=1.9"
 ]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Supports macOS Apple Silicon and MSVC 2019 (if we supported Windows, anyway).