### PR TITLE
Fix missing references in GooFit python bindings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,6 @@ project(
   GOOFIT
   VERSION 2.2.3
   LANGUAGES CXX)
-SET(CUDA_SEPARABLE_COMPILATION ON)
 #set(GOOFIT_TAG "dev")
 #set(GOOFIT_TAG "alpha")
 #set(GOOFIT_TAG "beta")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ project(
   GOOFIT
   VERSION 2.2.3
   LANGUAGES CXX)
-
+SET(CUDA_SEPARABLE_COMPILATION ON)
 #set(GOOFIT_TAG "dev")
 #set(GOOFIT_TAG "alpha")
 #set(GOOFIT_TAG "beta")

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -50,7 +50,7 @@ add_subdirectory(goofit)
 add_subdirectory(PDFs)
 
 process_pybind_module(_goofit)
-target_link_libraries(_goofit PRIVATE _goofit_python _Core _Basic _Combine _Physics)
+target_link_libraries(_goofit PRIVATE _goofit_python _Core _Basic _Combine _Physics PDFs)
 
 # Create files in the python directory
 

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -50,7 +50,7 @@ add_subdirectory(goofit)
 add_subdirectory(PDFs)
 
 process_pybind_module(_goofit)
-target_link_libraries(_goofit PRIVATE _goofit_python _Core _Basic _Combine _Physics PDFs)
+target_link_libraries(_goofit PRIVATE _goofit_python _Core _Basic _Combine _Physics)
 
 # Create files in the python directory
 

--- a/python/PDFs/basic/CMakeLists.txt
+++ b/python/PDFs/basic/CMakeLists.txt
@@ -23,7 +23,7 @@ add_library(
   VoigtianPdf.cpp)
 
 target_link_libraries(_Basic PRIVATE _goofit_python)
-set_target_properties(_Basic PROPERTIES FOLDER python/PDFs)
+set_target_properties(_Basic PROPERTIES FOLDER python/PDFs CUDA_RESOLVE_DEVICE_SYMBOLS ON)
 
 goofit_add_python_docs(_Basic PDFs/basic/ArgusPdf.h)
 goofit_add_python_docs(_Basic PDFs/basic/BifurGaussPdf.h)

--- a/python/PDFs/combine/CMakeLists.txt
+++ b/python/PDFs/combine/CMakeLists.txt
@@ -2,7 +2,7 @@ add_library(_Combine STATIC AddPdf.cpp CompositePdf.cpp ConvolutionPdf.cpp Event
                             MappedPdf.cpp ProdPdf.cpp)
 
 target_link_libraries(_Combine PRIVATE _goofit_python)
-set_target_properties(_Combine PROPERTIES FOLDER python/PDFs  CUDA_RESOLVE_DEVICE_SYMBOLS ON)
+set_target_properties(_Combine PROPERTIES FOLDER python/PDFs CUDA_RESOLVE_DEVICE_SYMBOLS ON)
 
 goofit_add_python_docs(_Combine PDFs/combine/AddPdf.h)
 goofit_add_python_docs(_Combine PDFs/combine/CompositePdf.h)

--- a/python/PDFs/combine/CMakeLists.txt
+++ b/python/PDFs/combine/CMakeLists.txt
@@ -2,7 +2,7 @@ add_library(_Combine STATIC AddPdf.cpp CompositePdf.cpp ConvolutionPdf.cpp Event
                             MappedPdf.cpp ProdPdf.cpp)
 
 target_link_libraries(_Combine PRIVATE _goofit_python)
-set_target_properties(_Combine PROPERTIES FOLDER python/PDFs)
+set_target_properties(_Combine PROPERTIES FOLDER python/PDFs  CUDA_RESOLVE_DEVICE_SYMBOLS ON)
 
 goofit_add_python_docs(_Combine PDFs/combine/AddPdf.h)
 goofit_add_python_docs(_Combine PDFs/combine/CompositePdf.h)

--- a/python/PDFs/physics/CMakeLists.txt
+++ b/python/PDFs/physics/CMakeLists.txt
@@ -21,7 +21,7 @@ goofit_add_library(
   SquareDalitzEffPdf.cpp)
 
 target_link_libraries(_Physics PRIVATE _goofit_python)
-set_target_properties(_Physics PROPERTIES FOLDER python/PDFs)
+set_target_properties(_Physics PROPERTIES FOLDER python/PDFs CUDA_RESOLVE_DEVICE_SYMBOLS ON)
 if(GOOFIT_KMATRIX)
   target_compile_definitions(_Physics PRIVATE GOOFIT_KMATRIX)
 endif()

--- a/python/PDFs/utilities/CMakeLists.txt
+++ b/python/PDFs/utilities/CMakeLists.txt
@@ -1,1 +1,2 @@
 target_sources(_goofit PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/VariableBinTransform1DPdf.cpp")
+set_target_properties(_goofit PROPERTIES CUDA_RESOLVE_DEVICE_SYMBOLS ON)


### PR DESCRIPTION
Changes to CMake to fix issues with missing references when using GooFit python bindings. Based on changes by  @danielsibemol 

On sneezy, the following setup should work for compiling GooFit
```
ml load gcc/7.5/cuda/11.2
source /usr/local/anaconda3/etc/profile.d/conda.sh
cmake -S . -B build-cuda -DGOOFIT_FORCE_LOCAL_THRUST=OFF -DGOOFIT_CERNROOT=OFF -DGOOFIT_PYTHON=ON -DGOOFIT_KMATRIX=ON -DGOOFIT_EXAMPLES=OFF -DGOOFIT_TESTS=OFF
cmake --build build-cuda/ -j 24
```
to use python bindings:
```
export PYTHONPATH=/share/lazy/freiss/GooFit/build-cuda (change accordingly)
```

Notes:
* it might be that not all of the changes are necessary
* after changing something, the build directory needs to be cleaned before re-compiling for the linking to work. Probably there are other changes to CMake required to fix
* needs adjustment in MCBooster external repository to compile

@danielsibemol 