### PR TITLE
chore: use pip clang format

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -5,8 +5,7 @@ See [`docs/SYSTEM_INSTALL.md`](../docs/SYSTEM_INSTALL.md) for help building and 
 ## Development
 
 All formatting is done with [pre-commit][]. Install with brew (`brew install
-pre-commit`) (macOS) or pip (any OS). You will need docker as well for
-pre-commit to run the clang-format step.
+pre-commit`) (macOS) or pipx/pip (any OS).
 
 [pre-commit]: https://pre-commit.com
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,14 +10,6 @@ on:
       - master
 
 jobs:
-  pre-commit:
-    name: Formatting
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
-    - uses: pre-commit/action@v2.0.3
-
   build:
     name: OMP / Test
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,8 +1,7 @@
 ci:
-  autoupdate_commit_msg: 'chore(style): pre-commit autoupdate'
-  skip:
-    - docker-clang-format
-exclude: '^.ci/azure-wheel-helpers/.*'
+  autoupdate_commit_msg: "chore: update pre-commit hooks"
+  autofix_commit_msg: "style: pre-commit fixes"
+
 repos:
 - repo: https://github.com/psf/black
   rev: 21.6b0
@@ -46,13 +45,7 @@ repos:
     entry: PyBind|Numpy|Cmake
     exclude: .pre-commit-config.yaml
 
-- repo: local
+- repo: https://github.com/ssciwr/clang-format-hook
+  rev: v12.0.1
   hooks:
-  - id: docker-clang-format
-    name: Docker Clang Format
-    language: docker_image
-    files: "\\.(cu|hpp|cpp|cu|h)$"
-    entry: unibeautify/clang-format:latest
-    args:
-    - -style=file
-    - -i
+   - id: clang-format

--- a/include/goofit/Error.h
+++ b/include/goofit/Error.h
@@ -9,7 +9,7 @@ namespace GooFit {
 /// Thrown when a general error is encountered
 struct GeneralError : public CLI::Error {
     template <typename... Args>
-    GeneralError(std::string name, Args &&... args)
+    GeneralError(std::string name, Args &&...args)
         : Error("GeneralError", fmt::format(name, std::forward<Args>(args)...), 2) {}
 };
 

--- a/include/goofit/PDFs/physics/MixingTimeResolution.h
+++ b/include/goofit/PDFs/physics/MixingTimeResolution.h
@@ -18,7 +18,7 @@ Represents a parametrization of the time resolution.
 class MixingTimeResolution : public GooPdf {
   public:
     template <class... Args>
-    MixingTimeResolution(std::string pdf_name, Args &&... args)
+    MixingTimeResolution(std::string pdf_name, Args &&...args)
         : GooPdf(pdf_name, "mixing_resolution", std::forward<Args>(args)...) {}
 
     ~MixingTimeResolution() override;


### PR DESCRIPTION
Using https://github.com/ssciwr/clang-format-wheel, 1-2 MB on all common platforms. Docker no longer required. Auto fixes now work. Ultra fast. Pinned to exact consistent versions. Auto updated.