### PR TITLE
refactor: nicer PC impl

### DIFF
--- a/include/goofit/PDFs/ParameterContainer.h
+++ b/include/goofit/PDFs/ParameterContainer.h
@@ -22,23 +22,21 @@ struct ParameterContainer {
 
     int funcIdx{0};
 
-    inline __device__ auto getParameter(const int i) -> fptype { return RO_CACHE(parameters[parameterIdx + i + 1]); }
+    inline __device__ fptype getParameter(const int i) const { return RO_CACHE(parameters[parameterIdx + i + 1]); }
 
-    inline __device__ auto getConstant(const int i) -> fptype { return RO_CACHE(constants[constantIdx + i + 1]); }
+    inline __device__ fptype getConstant(const int i) const { return RO_CACHE(constants[constantIdx + i + 1]); }
 
-    inline __device__ auto getObservable(const int i) -> fptype { return RO_CACHE(observables[observableIdx + i + 1]); }
+    inline __device__ fptype getObservable(const int i) const { return RO_CACHE(observables[observableIdx + i + 1]); }
 
-    inline __device__ auto getNormalization(const int i) -> fptype {
-        return RO_CACHE(normalizations[normalIdx + i + 1]);
-    }
+    inline __device__ fptype getNormalization(const int i) const { return RO_CACHE(normalizations[normalIdx + i + 1]); }
 
-    inline __device__ auto getNumParameters() -> int { return (int)RO_CACHE(parameters[parameterIdx]); }
+    inline __device__ int getNumParameters() const { return (int)RO_CACHE(parameters[parameterIdx]); }
 
-    inline __device__ auto getNumConstants() -> int { return (int)RO_CACHE(constants[constantIdx]); }
+    inline __device__ int getNumConstants() const { return (int)RO_CACHE(constants[constantIdx]); }
 
-    inline __device__ auto getNumObservables() -> int { return (int)RO_CACHE(observables[observableIdx]); }
+    inline __device__ int getNumObservables() const { return (int)RO_CACHE(observables[observableIdx]); }
 
-    inline __device__ auto getNumNormalizations() -> int { return (int)RO_CACHE(normalizations[normalIdx]); }
+    inline __device__ int getNumNormalizations() const { return (int)RO_CACHE(normalizations[normalIdx]); }
 
     // each PDF needs to supply the amount of each array used.
     // This function automatically adds +1 for the size.

--- a/src/PDFs/combine/AddPdf.cu
+++ b/src/PDFs/combine/AddPdf.cu
@@ -18,32 +18,30 @@ __device__ auto device_AddPdfs(fptype *evt, ParameterContainer &pc) -> fptype {
     fptype ret         = 0;
     fptype totalWeight = 0;
 
-    // make a copy of our parameter container
-    ParameterContainer pci = pc;
+    // Make a copy of our parameter container so we can continue to refer to
+    // our own parameters even though pc is moving forward.
+    const ParameterContainer local_pc = pc;
 
-    // We only call increment once we read our weight/norm for the first iteration.
-    pci.incrementIndex();
+    // We start by moving to the next function in the call chain
+    pc.incrementIndex();
 
     for(int i = 0; i < numParameters; i++) {
         // fetch our values from AddPdf
-        fptype weight = pc.getParameter(i);
+        fptype weight = local_pc.getParameter(i);
         totalWeight += weight;
 
         // This is the normal value for the 'callFunction' PDF, so we read from pci
-        fptype norm = pci.getNormalization(0);
+        fptype norm = pc.getNormalization(0);
 
         // call the first function to add in our PDF.
-        fptype curr = callFunction(evt, pci);
+        fptype curr = callFunction(evt, pc);
 
         ret += weight * curr * norm;
     }
 
-    // restore our new parameter container object
-    pc = pci;
-
     // previous functions incremented the indices appropriately, so now we need to get the norm again
     // NOTE: this is the weight for the function about to be called.
-    fptype normFactor = pc.getNormalization(0);
+    fptype normFactor = local_pc.getNormalization(0);
 
     fptype last = callFunction(evt, pc);
     ret += (1 - totalWeight) * last * normFactor;
@@ -56,25 +54,25 @@ __device__ auto device_AddPdfsExt(fptype *evt, ParameterContainer &pc) -> fptype
     fptype ret         = 0;
     fptype totalWeight = 0;
 
-    // make a copy of our parameter container
-    ParameterContainer pci = pc;
+    // Make a copy of our parameter container so we can continue to refer to
+    // our own parameters even though pc is moving forward.
+    const ParameterContainer local_pc = pc;
 
     // We only call increment once we read our weight/norm for the first iteration.
-    pci.incrementIndex();
+    pc.incrementIndex();
 
     for(int i = 0; i < numParameters; i++) {
         // grab the weight parameter from addPdf
-        fptype weight = pc.getParameter(i);
+        fptype weight = local_pc.getParameter(i);
         //  Grab the normalization for the specific component
-        fptype normFactor = pci.getNormalization(0);
+        fptype normFactor = pc.getNormalization(0);
 
-        fptype curr = callFunction(evt, pci);
+        fptype curr = callFunction(evt, pc);
         ret += weight * curr * normFactor;
 
         totalWeight += weight;
     }
 
-    pc = pci;
     ret /= totalWeight;
 
     return ret;


### PR DESCRIPTION
This should be easier to read, and cleaner. Three changes:

* Using classic return-type-first syntax for methods. The trailing return type was only added for special cases (where you need to compute the return type after the arguments), not for normal int's and floats.
* Make methods `const` that do not change the ParameterContainer.
* Make the parameter container copy the local one, rather than the one that's going to change. Make it `const` to ensure it remains the original PDF parameters.
