### PR TITLE
fix: support newer CMake, drop GOOFIT_CXX_STANDARD flag

### DIFF
--- a/.github/actions/cmake_config/entrypoint.sh
+++ b/.github/actions/cmake_config/entrypoint.sh
@@ -8,7 +8,12 @@ mkdir -p cmake_sources
 rm -rf cmake_dir/* build_tmp/*
 
 v=$1
-fn=cmake-$v-Linux-x86_64.tar.gz
+
+if [[ $v == 3.2* ]]; then
+    fn=cmake-$v-linux-x86_64.tar.gz
+else
+    fn=cmake-$v-Linux-x86_64.tar.gz
+fi
 
 if [ ! -f "cmake_souces/$fn" ]; then
     wget -qO "cmake_sources/$fn" "https://cmake.org/files/v${v%.*}/$fn"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
         submodules: true
 
     - name: Configure
-      run: cmake -S . -B build -DGOOFIT_DEVICE=OMP -DGOOFIT_CXX_STANDARD=14
+      run: cmake -S . -B build -DGOOFIT_DEVICE=OMP -DCMAKE_CXX_STANDARD=14
     - name: Build
       run: cmake --build build -j "$(getconf _NPROCESSORS_ONLN)"
     - name: Run Tests
@@ -74,7 +74,7 @@ jobs:
     - name: Add wget and python3
       run: apt-get update && apt-get install -y wget python3-dev
     - name: Install Modern CMake
-      run: wget -qO- "https://cmake.org/files/v3.23/cmake-3.23.1-linux-x86_64.tar.gz" | tar --strip-components=1 -xz -C /usr/local
+      run: wget -qO- "https://cmake.org/files/v3.23/cmake-3.23.2-linux-x86_64.tar.gz" | tar --strip-components=1 -xz -C /usr/local
     - name: Configure
       run: cmake -S . -B build -DGOOFIT_ARCH=3.5 -DGOOFIT_SPLASH=OFF
     - name: Build
@@ -90,106 +90,28 @@ jobs:
       with:
         submodules: true
 
-    - name: CMake 3.9 OMP
+    - name: CMake 3.18 OMP
       uses: ./.github/actions/cmake_config
       with:
-        version: 3.9.6
+        version: 3.18.6
         options: -DGOOFIT_DEVICE=OMP
       if: success() || failure()
-    - name: CMake 3.9 CUDA
+    - name: CMake 3.18 CUDA
       uses: ./.github/actions/cmake_config
       with:
-        version: 3.9.6
+        version: 3.18.6
         options: -DGOOFIT_DEVICE=CUDA
       if: success() || failure()
 
-    - name: CMake 3.10 OMP
+    - name: CMake 3.23 OMP
       uses: ./.github/actions/cmake_config
       with:
-        version: 3.10.3
+        version: 3.23.1
         options: -DGOOFIT_DEVICE=OMP
       if: success() || failure()
-    - name: CMake 3.10 CUDA
+    - name: CMake 3.23 CUDA
       uses: ./.github/actions/cmake_config
       with:
-        version: 3.10.3
-        options: -DGOOFIT_DEVICE=CUDA
-      if: success() || failure()
-
-    - name: CMake 3.11 OMP
-      uses: ./.github/actions/cmake_config
-      with:
-        version: 3.11.4
-        options: -DGOOFIT_DEVICE=OMP
-      if: success() || failure()
-    - name: CMake 3.11 CUDA
-      uses: ./.github/actions/cmake_config
-      with:
-        version: 3.11.4
-        options: -DGOOFIT_DEVICE=OMP
-      if: success() || failure()
-
-    - name: CMake 3.12 OMP
-      uses: ./.github/actions/cmake_config
-      with:
-        version: 3.12.4
-        options: -DGOOFIT_DEVICE=OMP
-      if: success() || failure()
-    - name: CMake 3.12 CUDA
-      uses: ./.github/actions/cmake_config
-      with:
-        version: 3.12.4
-        options: -DGOOFIT_DEVICE=CUDA
-      if: success() || failure()
-
-    - name: CMake 3.13 OMP
-      uses: ./.github/actions/cmake_config
-      with:
-        version: 3.13.5
-        options: -DGOOFIT_DEVICE=OMP
-      if: success() || failure()
-    - name: CMake 3.13 CUDA
-      uses: ./.github/actions/cmake_config
-      with:
-        version: 3.13.5
-        options: -DGOOFIT_DEVICE=CUDA
-      if: success() || failure()
-
-    - name: CMake 3.14 OMP
-      uses: ./.github/actions/cmake_config
-      with:
-        version: 3.14.7
-        options: -DGOOFIT_DEVICE=OMP
-      if: success() || failure()
-    - name: CMake 3.14 CUDA
-      uses: ./.github/actions/cmake_config
-      with:
-        version: 3.14.7
-        options: -DGOOFIT_DEVICE=CUDA
-      if: success() || failure()
-
-    - name: CMake 3.15 OMP
-      uses: ./.github/actions/cmake_config
-      with:
-        version: 3.15.7
-        options: -DGOOFIT_DEVICE=OMP
-      if: success() || failure()
-    - name: CMake 3.15 CUDA
-      uses: ./.github/actions/cmake_config
-      with:
-        version: 3.15.7
-        options: -DGOOFIT_DEVICE=CUDA
-      if: success() || failure()
-
-    - name: CMake 3.16 OMP
-      uses: ./.github/actions/cmake_config
-      with:
-        version: 3.16.4
-        options: -DGOOFIT_DEVICE=OMP
-      if: success() || failure()
-    - name: CMake 3.16 CUDA
-      uses: ./.github/actions/cmake_config
-      with:
-        version: 3.16.4
+        version: 3.23.1
         options: -DGOOFIT_DEVICE=CUDA
       if: success() || failure()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -385,8 +385,8 @@ if(NOT THRUST_FOUND)
 endif()
 
 option(GOOFIT_FORCE_LOCAL_THRUST
-        "GooFit will use the GitHub version of Thrust by default (CUDA 9 and 10's Thrust is buggy)"
-        ON)
+       "GooFit will use the GitHub version of Thrust by default (CUDA 9 and 10's Thrust is buggy)"
+       ON)
 if(GOOFIT_FORCE_LOCAL_THRUST)
   message(
     STATUS "Forcing local thrust. GOOFIT_FORCE_LOCAL_THRUST=OFF to disable. Requires CUDA < 10.1")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,4 @@
-cmake_minimum_required(VERSION 3.9...3.15)
-
-if(${CMAKE_VERSION} VERSION_LESS 3.12)
-  cmake_policy(VERSION ${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION})
-endif()
+cmake_minimum_required(VERSION 3.16...3.23)
 
 project(
   GOOFIT
@@ -134,17 +130,16 @@ set(GOOFIT_CUDA_OR_GRAINSIZE
 configure_file("${GOOFIT_SOURCE_DIR}/include/goofit/detail/ThrustOverrideConfig.h.in"
                "${GOOFIT_BINARY_DIR}/include/goofit/detail/ThrustOverrideConfig.h")
 
-set(GOOFIT_CXX_STANDARD
-    "11"
+set(CMAKE_CXX_STANDARD
+    "14"
     CACHE STRING
           "Set a version of C++ standerd (11,14,...) to use. Must match ROOT if using ROOT.")
-set(GOOFIT_CXX_CUDA_STANDARD
-    "11"
+set(CMAKE_CUDA_STANDARD
+    "14"
     CACHE STRING "Set a version of C++ standerd (11,14,...) to use in CUDA.")
 
 ### C++ settings ###
 macro(GOOFIT_SETUP_STD)
-  set(CMAKE_CXX_STANDARD ${GOOFIT_CXX_STANDARD})
   set(CMAKE_CXX_EXTENSIONS OFF)
   set(CMAKE_CXX_STANDARD_REQUIRED ON)
   set(CMAKE_POSITION_INDEPENDENT_CODE ON)
@@ -323,7 +318,6 @@ endif()
 macro(GOOFIT_OPTIONAL_CUDA)
   if(GOOFIT_DEVICE STREQUAL CUDA)
     enable_language(CUDA)
-    set(CMAKE_CUDA_STANDARD ${GOOFIT_CXX_CUDA_STANDARD})
     set(CMAKE_CUDA_STANDARD_REQUIRED ON)
     set(CMAKE_CUDA_EXTENSIONS OFF)
 
@@ -354,19 +348,6 @@ if(GOOFIT_DEVICE STREQUAL CUDA)
   # Note that this should be the only nvlink command
   string(APPEND CMAKE_CUDA_FLAGS " -Xnvlink=--disable-warnings")
   string(APPEND CMAKE_CUDA_FLAGS " -Xcompiler=-Wno-attributes")
-
-  if(NOT DEFINED GOOFIT_ARCH OR GOOFIT_ARCH)
-    cmake_cuda_arch_select(FLAGS ARCH_FLAGS READABLE ARCH_FLAGS_readable ARCHS ${GOOFIT_ARCH})
-    string(REPLACE ";" ", " READ_ARCH_FLAGS "${ARCH_FLAGS_readable}")
-    string(REPLACE ";" " " ARCH_FLAGS "${ARCH_FLAGS}")
-    string(APPEND CMAKE_CUDA_FLAGS " ${ARCH_FLAGS}")
-    set(CMAKE_CUDA_FLAGS
-        "${CMAKE_CUDA_FLAGS}"
-        CACHE INTERNAL "")
-    message(STATUS "Compiling for GPU arch: ${READ_ARCH_FLAGS}")
-  else()
-    message(STATUS "Not compiling for a specific GPU arch")
-  endif()
 
   set(THRUST_INCLUDE_DIR "${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES}")
 
@@ -404,8 +385,8 @@ if(NOT THRUST_FOUND)
 endif()
 
 option(GOOFIT_FORCE_LOCAL_THRUST
-       "GooFit will use the GitHub version of Thrust by default (CUDA 9 and 10's Thrust is buggy)"
-       ON)
+        "GooFit will use the GitHub version of Thrust by default (CUDA 9 and 10's Thrust is buggy)"
+        ON)
 if(GOOFIT_FORCE_LOCAL_THRUST)
   message(
     STATUS "Forcing local thrust. GOOFIT_FORCE_LOCAL_THRUST=OFF to disable. Requires CUDA < 10.1")
@@ -736,9 +717,6 @@ endif()
 
 add_feature_info("GOOFIT_DEVICE=${GOOFIT_DEVICE}" ON "The device to compile for")
 add_feature_info("GOOFIT_HOST=${GOOFIT_HOST}" ON "The host system to compile for")
-if(GOOFIT_DEVICE STREQUAL CUDA)
-  add_feature_info("ARCH_FLAGS=${READ_ARCH_FLAGS}" ON "Readable GPU arch flags")
-endif()
 
 feature_option(GOOFIT_KMATRIX)
 feature_option(GOOFIT_TRACE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,11 +131,11 @@ configure_file("${GOOFIT_SOURCE_DIR}/include/goofit/detail/ThrustOverrideConfig.
                "${GOOFIT_BINARY_DIR}/include/goofit/detail/ThrustOverrideConfig.h")
 
 set(CMAKE_CXX_STANDARD
-    "14"
+    "11"
     CACHE STRING
           "Set a version of C++ standerd (11,14,...) to use. Must match ROOT if using ROOT.")
 set(CMAKE_CUDA_STANDARD
-    "14"
+    "11"
     CACHE STRING "Set a version of C++ standerd (11,14,...) to use in CUDA.")
 
 ### C++ settings ###


### PR DESCRIPTION
Trying to update while avoiding the GCC ICE, partial update from #321.