### PR TITLE
fix crash on GPU of SquareDalitzEfficiency and SmoothHistogramPdf

### DIFF
--- a/src/PDFs/basic/SmoothHistogramPdf.cu
+++ b/src/PDFs/basic/SmoothHistogramPdf.cu
@@ -25,7 +25,8 @@ __device__ auto device_EvalHistogram(fptype *evt, ParameterContainer &pc) -> fpt
         int varIndex      = pc.getObservable(i);
         int lowerBoundIdx = 3 * (i + 1);
 
-        fptype currVariable = RO_CACHE(evt[varIndex]);
+        // don't use RO_CACHE as this is used as efficiency for Amp3Body
+        fptype currVariable = evt[varIndex];
         fptype lowerBound   = pc.getConstant(i * 3 + 4);
         fptype step         = pc.getConstant(i * 3 + 5);
 

--- a/src/PDFs/physics/SquareDalitzEffPdf.cu
+++ b/src/PDFs/physics/SquareDalitzEffPdf.cu
@@ -32,7 +32,6 @@ __device__ auto device_SquareDalitzEff(fptype *evt, ParameterContainer &pc) -> f
     int idx = pc.getObservable(0);
     int idy = pc.getObservable(1);
 
-
     // don't use RO_CACHE as this is used as efficiency for Amp3Body
     fptype x = evt[idx];
     fptype y = evt[idy];

--- a/src/PDFs/physics/SquareDalitzEffPdf.cu
+++ b/src/PDFs/physics/SquareDalitzEffPdf.cu
@@ -32,8 +32,10 @@ __device__ auto device_SquareDalitzEff(fptype *evt, ParameterContainer &pc) -> f
     int idx = pc.getObservable(0);
     int idy = pc.getObservable(1);
 
-    fptype x = RO_CACHE(evt[idx]);
-    fptype y = RO_CACHE(evt[idy]);
+
+    // don't use RO_CACHE as this is used as efficiency for Amp3Body
+    fptype x = evt[idx];
+    fptype y = evt[idy];
 
     // Define coefficients
     fptype c0 = pc.getParameter(0);

--- a/src/PDFs/physics/detail/SpecialResonanceIntegrator.cu
+++ b/src/PDFs/physics/detail/SpecialResonanceIntegrator.cu
@@ -104,6 +104,7 @@ __device__ auto SpecialResonanceIntegrator::operator()(thrust::tuple<int, fptype
     while(pc.funcIdx < effFunc)
         pc.incrementIndex();
 
+    // make sure that the efficiency function does not use RO_CACHE to access events, as this will cause a crash on GPU (accessing stack memory is not allowed with ldg)
     fptype eff = callFunction(events, pc);
 
     // Multiplication by eff, not sqrt(eff), is correct:

--- a/src/PDFs/physics/detail/SpecialResonanceIntegrator.cu
+++ b/src/PDFs/physics/detail/SpecialResonanceIntegrator.cu
@@ -104,7 +104,8 @@ __device__ auto SpecialResonanceIntegrator::operator()(thrust::tuple<int, fptype
     while(pc.funcIdx < effFunc)
         pc.incrementIndex();
 
-    // make sure that the efficiency function does not use RO_CACHE to access events, as this will cause a crash on GPU (accessing stack memory is not allowed with ldg)
+    // make sure that the efficiency function does not use RO_CACHE to access events, as this will cause a crash on GPU
+    // (accessing stack memory is not allowed with ldg)
     fptype eff = callFunction(events, pc);
 
     // Multiplication by eff, not sqrt(eff), is correct:


### PR DESCRIPTION
there might be smarter ways to do it, but since those functions only are used as efficiencies for Amp3Body this should be fine for now

closes #216 #217 