### PR TITLE
Allocate larger stack size for the kMatrix

### DIFF
--- a/include/goofit/PDFs/MetricTaker.h
+++ b/include/goofit/PDFs/MetricTaker.h
@@ -5,12 +5,11 @@
 #include <goofit/PdfBase.h>
 
 #define cuda_error_check(stat)
-  {
-    cudaErrCheck_((stat), __FILE__, __LINE__);
-  }
-void inline cudaErrCheck_(cudaError_t stat, const char *file, int line)
-{
-  if (stat != cudaSuccess) { fprintf(stderr, "CUDA Error: %s %s %d\n", cudaGetErrorString(stat), file, line); }
+{ cudaErrCheck_((stat), __FILE__, __LINE__); }
+void inline cudaErrCheck_(cudaError_t stat, const char *file, int line) {
+    if(stat != cudaSuccess) {
+        fprintf(stderr, "CUDA Error: %s %s %d\n", cudaGetErrorString(stat), file, line);
+    }
 }
 
 namespace GooFit {

--- a/include/goofit/PDFs/MetricTaker.h
+++ b/include/goofit/PDFs/MetricTaker.h
@@ -4,10 +4,11 @@
 
 #include <goofit/PdfBase.h>
 
-#define cuda_error_check(stat)
-  {
-    cudaErrCheck_((stat), __FILE__, __LINE__);
+#define cuda_error_check(stat)                                                                                         \
+  {                                                                                                                    \
+    cudaErrCheck_((stat), __FILE__, __LINE__);                                                                         \
   }
+
 void inline cudaErrCheck_(cudaError_t stat, const char *file, int line)
 {
   if (stat != cudaSuccess) { fprintf(stderr, "CUDA Error: %s %s %d\n", cudaGetErrorString(stat), file, line); }

--- a/include/goofit/PDFs/MetricTaker.h
+++ b/include/goofit/PDFs/MetricTaker.h
@@ -4,6 +4,7 @@
 
 #include <goofit/PdfBase.h>
 
+#if THRUST_DEVICE_SYSTEM == THRUST_DEVICE_SYSTEM_CUDA
 #define cuda_error_check(stat)                                                                                         \
     { cudaErrCheck_((stat), __FILE__, __LINE__); }
 
@@ -12,6 +13,7 @@ void inline cudaErrCheck_(cudaError_t stat, const char *file, int line) {
         fprintf(stderr, "CUDA Error: %s %s %d\n", cudaGetErrorString(stat), file, line);
     }
 }
+#endif
 
 namespace GooFit {
 

--- a/include/goofit/PDFs/MetricTaker.h
+++ b/include/goofit/PDFs/MetricTaker.h
@@ -5,13 +5,12 @@
 #include <goofit/PdfBase.h>
 
 #define cuda_error_check(stat)                                                                                         \
-  {                                                                                                                    \
-    cudaErrCheck_((stat), __FILE__, __LINE__);                                                                         \
-  }
+    { cudaErrCheck_((stat), __FILE__, __LINE__); }
 
-void inline cudaErrCheck_(cudaError_t stat, const char *file, int line)
-{
-  if (stat != cudaSuccess) { fprintf(stderr, "CUDA Error: %s %s %d\n", cudaGetErrorString(stat), file, line); }
+void inline cudaErrCheck_(cudaError_t stat, const char *file, int line) {
+    if(stat != cudaSuccess) {
+        fprintf(stderr, "CUDA Error: %s %s %d\n", cudaGetErrorString(stat), file, line);
+    }
 }
 
 namespace GooFit {

--- a/include/goofit/PDFs/MetricTaker.h
+++ b/include/goofit/PDFs/MetricTaker.h
@@ -4,6 +4,15 @@
 
 #include <goofit/PdfBase.h>
 
+#define cuda_error_check(stat)
+  {
+    cudaErrCheck_((stat), __FILE__, __LINE__);
+  }
+void inline cudaErrCheck_(cudaError_t stat, const char *file, int line)
+{
+  if (stat != cudaSuccess) { fprintf(stderr, "CUDA Error: %s %s %d\n", cudaGetErrorString(stat), file, line); }
+}
+
 namespace GooFit {
 
 // Notice that operators are distinguished by the order of the operands,

--- a/src/PDFs/MetricTaker.cu
+++ b/src/PDFs/MetricTaker.cu
@@ -127,7 +127,7 @@ MetricTaker::MetricTaker(int fIdx, int pIdx)
 
     // Set a larger stack size. Needed for the kMatrix because the stack size
     // can't be determined at runtime.
-#if THRUST_DEVICE_SYSTEM == THRUST_DEVICE_SYSTEM_CUDA    
+#if THRUST_DEVICE_SYSTEM == THRUST_DEVICE_SYSTEM_CUDA
     cuda_error_check(cudaDeviceSetLimit(cudaLimitStackSize, 1024 * 50));
 #endif
 }

--- a/src/PDFs/MetricTaker.cu
+++ b/src/PDFs/MetricTaker.cu
@@ -114,7 +114,9 @@ MetricTaker::MetricTaker(PdfBase *dat, void *dev_functionPtr)
 
     // Set a larger stack size. Needed for the kMatrix because the stack size
     // can't be determined at runtime.
+#if THRUST_DEVICE_SYSTEM == THRUST_DEVICE_SYSTEM_CUDA
     cuda_error_check(cudaDeviceSetLimit(cudaLimitStackSize, 1024 * 50));
+#endif
 }
 
 MetricTaker::MetricTaker(int fIdx, int pIdx)
@@ -125,7 +127,9 @@ MetricTaker::MetricTaker(int fIdx, int pIdx)
 
     // Set a larger stack size. Needed for the kMatrix because the stack size
     // can't be determined at runtime.
+#if THRUST_DEVICE_SYSTEM == THRUST_DEVICE_SYSTEM_CUDA    
     cuda_error_check(cudaDeviceSetLimit(cudaLimitStackSize, 1024 * 50));
+#endif
 }
 
 } // namespace GooFit

--- a/src/PDFs/MetricTaker.cu
+++ b/src/PDFs/MetricTaker.cu
@@ -111,6 +111,10 @@ MetricTaker::MetricTaker(PdfBase *dat, void *dev_functionPtr)
         host_function_table.push_back(dev_functionPtr);
         host_function_table.sync(d_function_table);
     }
+
+    // Set a larger stack size. Needed for the kMatrix because the stack size
+    // can't be determined at runtime.
+    cuda_error_check(cudaDeviceSetLimit(cudaLimitStackSize, 1024*50));
 }
 
 MetricTaker::MetricTaker(int fIdx, int pIdx)
@@ -118,6 +122,10 @@ MetricTaker::MetricTaker(int fIdx, int pIdx)
     , functionIdx(fIdx)
     , parameters(pIdx) {
     // This constructor should only be used for binned evaluation, ie for integrals.
+
+    // Set a larger stack size. Needed for the kMatrix because the stack size
+    // can't be determined at runtime.
+    cuda_error_check(cudaDeviceSetLimit(cudaLimitStackSize, 1024*50));
 }
 
 } // namespace GooFit

--- a/src/PDFs/MetricTaker.cu
+++ b/src/PDFs/MetricTaker.cu
@@ -114,7 +114,7 @@ MetricTaker::MetricTaker(PdfBase *dat, void *dev_functionPtr)
 
     // Set a larger stack size. Needed for the kMatrix because the stack size
     // can't be determined at runtime.
-    cuda_error_check(cudaDeviceSetLimit(cudaLimitStackSize, 1024*50));
+    cuda_error_check(cudaDeviceSetLimit(cudaLimitStackSize, 1024 * 50));
 }
 
 MetricTaker::MetricTaker(int fIdx, int pIdx)
@@ -125,7 +125,7 @@ MetricTaker::MetricTaker(int fIdx, int pIdx)
 
     // Set a larger stack size. Needed for the kMatrix because the stack size
     // can't be determined at runtime.
-    cuda_error_check(cudaDeviceSetLimit(cudaLimitStackSize, 1024*50));
+    cuda_error_check(cudaDeviceSetLimit(cudaLimitStackSize, 1024 * 50));
 }
 
 } // namespace GooFit

--- a/src/PDFs/physics/kMatrixUtils.cu
+++ b/src/PDFs/physics/kMatrixUtils.cu
@@ -131,9 +131,9 @@ __device__ void luDecomposition(fpcomplex A[NCHANNELS][NCHANNELS],
 }
 
 __device__ bool luInverse(fpcomplex A[NCHANNELS][NCHANNELS], fpcomplex inverse[NCHANNELS][NCHANNELS]) {
-    fpcomplex U[NCHANNELS][NCHANNELS];
-    fpcomplex L[NCHANNELS][NCHANNELS];
-    fpcomplex Linv[NCHANNELS][NCHANNELS];
+    fpcomplex U[NCHANNELS][NCHANNELS] = {0};
+    fpcomplex L[NCHANNELS][NCHANNELS] = {0};
+    fpcomplex Linv[NCHANNELS][NCHANNELS] = {0};
     luDecomposition(A, U, L);
 
     // Compute intermediate matrix Linv.
@@ -170,58 +170,18 @@ __device__ void getPropagator(const fptype kMatrix[NCHANNELS][NCHANNELS],
                               const fpcomplex phaseSpace[NCHANNELS],
                               fpcomplex F[NCHANNELS][NCHANNELS],
                               fptype adlerTerm) {
+
     fpcomplex tMatrix[NCHANNELS][NCHANNELS];
     tMatrix[0][0] = fpcomplex(0, 0);
 
     for(unsigned int i = 0; i < NCHANNELS; ++i) {
         for(unsigned int j = 0; j < NCHANNELS; ++j) {
             tMatrix[i][j] = (i == j ? 1. : 0.) - fpcomplex(0, adlerTerm) * kMatrix[i][j] * phaseSpace[j];
-            // printf("tMatrix(%i,%i) = (%f,%f), kMatrix(%i,%i) = %f, phaseSpace = (%f,%f) \n",
-            //       i,
-            //       j,
-            //       tMatrix[i][j].real(),
-            //       tMatrix[i][j].imag(),
-            //       i,
-            //       j,
-            //       kMatrix[i][j],
-            //       phaseSpace[j].real(),
-            //       phaseSpace[j].imag());
         }
     }
-
-    /*#if THRUST_DEVICE_SYSTEM == THRUST_DEVICE_SYSTEM_CUDA
-    // Here we assume that some values are 0
-        F = compute_inverse5<-1,
-                                -1,
-                                0,
-                                -1,
-                                -1,
-                                -1,
-                                -1,
-                                0,
-                                -1,
-                                -1,
-                                -1,
-                                -1,
-                                -1,
-                                -1,
-                                -1,
-                                -1,
-                                -1,
-                                -1,
-                                -1,
-                                -1,
-                                -1,
-                                -1,
-                                -1,
-                                -1,
-                                -1>(tMatrix);
-    #else
-    */
-
+    
     luInverse(tMatrix, F);
     return;
-    //#endif
 }
 
 } // namespace GooFit

--- a/src/PDFs/physics/kMatrixUtils.cu
+++ b/src/PDFs/physics/kMatrixUtils.cu
@@ -131,8 +131,8 @@ __device__ void luDecomposition(fpcomplex A[NCHANNELS][NCHANNELS],
 }
 
 __device__ bool luInverse(fpcomplex A[NCHANNELS][NCHANNELS], fpcomplex inverse[NCHANNELS][NCHANNELS]) {
-    fpcomplex U[NCHANNELS][NCHANNELS] = {0};
-    fpcomplex L[NCHANNELS][NCHANNELS] = {0};
+    fpcomplex U[NCHANNELS][NCHANNELS]    = {0};
+    fpcomplex L[NCHANNELS][NCHANNELS]    = {0};
     fpcomplex Linv[NCHANNELS][NCHANNELS] = {0};
     luDecomposition(A, U, L);
 
@@ -170,7 +170,6 @@ __device__ void getPropagator(const fptype kMatrix[NCHANNELS][NCHANNELS],
                               const fpcomplex phaseSpace[NCHANNELS],
                               fpcomplex F[NCHANNELS][NCHANNELS],
                               fptype adlerTerm) {
-
     fpcomplex tMatrix[NCHANNELS][NCHANNELS];
     tMatrix[0][0] = fpcomplex(0, 0);
 
@@ -179,7 +178,7 @@ __device__ void getPropagator(const fptype kMatrix[NCHANNELS][NCHANNELS],
             tMatrix[i][j] = (i == j ? 1. : 0.) - fpcomplex(0, adlerTerm) * kMatrix[i][j] * phaseSpace[j];
         }
     }
-    
+
     luInverse(tMatrix, F);
     return;
 }


### PR DESCRIPTION
Allocates a stack size of 50 kB in the metric taker. This is large enough for models that include a kMatrix resonance. In addition, this PR fixes a bug in the LU decomposition used for matrix inversion and removes some old commented code.

FYI @FlorianReiss @JuanBSLeite @henryiii