### PR TITLE
Draft: Fix logic incrementing cyclic index in RBW

### DIFF
--- a/src/PDFs/physics/resonances/RBW.cu
+++ b/src/PDFs/physics/resonances/RBW.cu
@@ -78,7 +78,7 @@ __device__ auto plainBW(fptype m12, fptype m13, fptype m23, ParameterContainer &
         result += ret;
 
         if(I > 1) {
-            cyclic_index = cyclic_index + 1 % 3;
+            cyclic_index = (cyclic_index + 1) % 3;
         }
     }
     pc.incrementIndex(1, 2, 3, 0, 1);


### PR DESCRIPTION
I noticed that the logic for incrementing the cyclic index of the 3-body RBW looked strange, as it always just incremented by `1 % 3 = 1`. I think what I've done here is correct.

@JuanBSLeite could this be related to the issues you were seeing with symmetrization? Could you see if this fixes that issue?

@FlorianReiss @JuanBSLeite @jcob95 it'd be helpful if one of you could double check my logic here.