### PR TITLE
Set CUDA stack size in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -268,7 +268,7 @@ target_compile_definitions(GooFit_Common
 # target_compile_definitions(GooFit_Common INTERFACE _USE_MATH_DEFINES)
 
 #define macro to set stack size (in kb)
-if (DEFINED GOOFIT_CUDA_STACKSIZE)
+if(DEFINED GOOFIT_CUDA_STACKSIZE)
   target_compile_definitions(GooFit_Common INTERFACE CUDA_STACKSIZE=${GOOFIT_CUDA_STACKSIZE})
 else()
   target_compile_definitions(GooFit_Common INTERFACE CUDA_STACKSIZE=1024)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -268,7 +268,11 @@ target_compile_definitions(GooFit_Common
 # target_compile_definitions(GooFit_Common INTERFACE _USE_MATH_DEFINES)
 
 #define macro to set stack size (in kb)
-target_compile_definitions(GooFit_Common INTERFACE CUDA_STACKSIZE=1024)
+if (DEFINED GOOFIT_CUDA_STACKSIZE)
+  target_compile_definitions(GooFit_Common INTERFACE CUDA_STACKSIZE=${GOOFIT_CUDA_STACKSIZE})
+else()
+  target_compile_definitions(GooFit_Common INTERFACE CUDA_STACKSIZE=1024)
+endif()
 
 option(GOOFIT_DEBUG "Print debugging messages" OFF)
 option(GOOFIT_TRACE "Print messages to trace the behavior of GooFit" OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -268,7 +268,7 @@ target_compile_definitions(GooFit_Common
 # target_compile_definitions(GooFit_Common INTERFACE _USE_MATH_DEFINES)
 
 #define macro to set stack size (in kb)
-target_compile_definitions(GooFit_Common INTERFACE CUDA_STACKSIZE=1024) 
+target_compile_definitions(GooFit_Common INTERFACE CUDA_STACKSIZE=1024)
 
 option(GOOFIT_DEBUG "Print debugging messages" OFF)
 option(GOOFIT_TRACE "Print messages to trace the behavior of GooFit" OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -267,6 +267,9 @@ target_compile_definitions(GooFit_Common
                            INTERFACE "-DTHRUST_HOST_SYSTEM=THRUST_HOST_SYSTEM_${GOOFIT_HOST}")
 # target_compile_definitions(GooFit_Common INTERFACE _USE_MATH_DEFINES)
 
+#define macro to set stack size (in kb)
+target_compile_definitions(GooFit_Common INTERFACE CUDA_STACKSIZE=1024) 
+
 option(GOOFIT_DEBUG "Print debugging messages" OFF)
 option(GOOFIT_TRACE "Print messages to trace the behavior of GooFit" OFF)
 

--- a/src/PDFs/MetricTaker.cu
+++ b/src/PDFs/MetricTaker.cu
@@ -115,7 +115,10 @@ MetricTaker::MetricTaker(PdfBase *dat, void *dev_functionPtr)
     // Set a larger stack size. Needed for the kMatrix because the stack size
     // can't be determined at runtime.
 #if THRUST_DEVICE_SYSTEM == THRUST_DEVICE_SYSTEM_CUDA
-    cuda_error_check(cudaDeviceSetLimit(cudaLimitStackSize, 1024 * 50));
+    cuda_error_check(cudaDeviceSetLimit(cudaLimitStackSize, CUDA_STACKSIZE));
+    size_t limit = 0;
+    cudaDeviceGetLimit(&limit, cudaLimitStackSize);
+    printf("New cudaLimitStackSize: %u\n", (unsigned)limit);
 #endif
 }
 
@@ -128,7 +131,10 @@ MetricTaker::MetricTaker(int fIdx, int pIdx)
     // Set a larger stack size. Needed for the kMatrix because the stack size
     // can't be determined at runtime.
 #if THRUST_DEVICE_SYSTEM == THRUST_DEVICE_SYSTEM_CUDA
-    cuda_error_check(cudaDeviceSetLimit(cudaLimitStackSize, 1024 * 50));
+    cuda_error_check(cudaDeviceSetLimit(cudaLimitStackSize, CUDA_STACKSIZE));
+    size_t limit = 0;
+    cudaDeviceGetLimit(&limit, cudaLimitStackSize);		    
+    printf("New cudaLimitStackSize: %u\n", (unsigned)limit);
 #endif
 }
 

--- a/src/PDFs/MetricTaker.cu
+++ b/src/PDFs/MetricTaker.cu
@@ -118,7 +118,6 @@ MetricTaker::MetricTaker(PdfBase *dat, void *dev_functionPtr)
     cuda_error_check(cudaDeviceSetLimit(cudaLimitStackSize, CUDA_STACKSIZE));
     size_t limit = 0;
     cudaDeviceGetLimit(&limit, cudaLimitStackSize);
-    printf("New cudaLimitStackSize: %u\n", (unsigned)limit);
 #endif
 }
 
@@ -134,7 +133,6 @@ MetricTaker::MetricTaker(int fIdx, int pIdx)
     cuda_error_check(cudaDeviceSetLimit(cudaLimitStackSize, CUDA_STACKSIZE));
     size_t limit = 0;
     cudaDeviceGetLimit(&limit, cudaLimitStackSize);
-    printf("New cudaLimitStackSize: %u\n", (unsigned)limit);
 #endif
 }
 

--- a/src/PDFs/MetricTaker.cu
+++ b/src/PDFs/MetricTaker.cu
@@ -133,7 +133,7 @@ MetricTaker::MetricTaker(int fIdx, int pIdx)
 #if THRUST_DEVICE_SYSTEM == THRUST_DEVICE_SYSTEM_CUDA
     cuda_error_check(cudaDeviceSetLimit(cudaLimitStackSize, CUDA_STACKSIZE));
     size_t limit = 0;
-    cudaDeviceGetLimit(&limit, cudaLimitStackSize);		    
+    cudaDeviceGetLimit(&limit, cudaLimitStackSize);
     printf("New cudaLimitStackSize: %u\n", (unsigned)limit);
 #endif
 }


### PR DESCRIPTION
Currently the CUDA stack size is set to 50mb in MetricTaker.cu. This causes a very large overhead for older GPU models and leads to very long execution times (~10 minutes to execute exponential.py example on a Tesla K4!!!), even on code which doesn't require this increase in stack size.

To avoid this, set the stack size in CMake by defining a preprocessor macro which can be set by the user as and when a larger stack size is necessary.

Does the way I have defined this macro in CMake mean that this can be set as a CMake flag, e.g. -DCUDA_STACKSIZE=2048?

FYI:@thboettc, @FlorianReiss , @henryiii 