### PR TITLE
Fix Amp4Body_TD GenerateSig

### DIFF
--- a/python/PDFs/physics/Amp4Body_TD.cu
+++ b/python/PDFs/physics/Amp4Body_TD.cu
@@ -47,13 +47,15 @@ void init_Amp4Body_TD(py::module &m) {
 
                  std::tie(particles, variables, weights, flags) = self.GenerateSig(numEvents);
 
-                 py::array_t<fptype> pyparticles{{(size_t)4, numEvents, (size_t)4}};
-                 py::array_t<fptype> pyvariables{{(size_t)6, numEvents}};
-                 py::array_t<fptype> pyweights{static_cast<py::ssize_t>(numEvents)};
-                 py::array_t<bool> pyflags{static_cast<py::ssize_t>(numEvents)};
+                size_t nAcc = weights.size();
+
+                 py::array_t<fptype> pyparticles{{(size_t)4, nAcc, (size_t)4}};
+                 py::array_t<fptype> pyvariables{{(size_t)6, nAcc}};
+                 py::array_t<fptype> pyweights{static_cast<py::ssize_t>(nAcc)};
+                 py::array_t<bool> pyflags{static_cast<py::ssize_t>(nAcc)};
 
                  for(int i = 0; i < 4; i++) {
-                     for(int j = 0; j < numEvents; j++) {
+                     for(int j = 0; j < nAcc; j++) {
                          for(int k = 0; k < 4; k++) {
                              pyparticles.mutable_at(i, j, k) = (*(particles[i]))[j].get(k);
                          }
@@ -61,16 +63,16 @@ void init_Amp4Body_TD(py::module &m) {
                  }
 
                  for(int i = 0; i < 6; i++) {
-                     for(int j = 0; j < numEvents; j++) {
+                     for(int j = 0; j < nAcc; j++) {
                          pyvariables.mutable_at(i, j) = (*(variables[i]))[j];
                      }
                  }
 
-                 for(int i = 0; i < numEvents; i++) {
+                 for(int i = 0; i < nAcc; i++) {
                      pyweights.mutable_at(i) = weights[i];
                  }
 
-                 for(int i = 0; i < numEvents; i++) {
+                 for(int i = 0; i < nAcc; i++) {
                      pyflags.mutable_at(i) = flags[i];
                  }
                  delete variables[0];

--- a/python/PDFs/physics/Amp4Body_TD.cu
+++ b/python/PDFs/physics/Amp4Body_TD.cu
@@ -47,7 +47,7 @@ void init_Amp4Body_TD(py::module &m) {
 
                  std::tie(particles, variables, weights, flags) = self.GenerateSig(numEvents);
 
-                size_t nAcc = weights.size();
+                 size_t nAcc = weights.size();
 
                  py::array_t<fptype> pyparticles{{(size_t)4, nAcc, (size_t)4}};
                  py::array_t<fptype> pyvariables{{(size_t)6, nAcc}};

--- a/python/examples/generate_sig_example.py
+++ b/python/examples/generate_sig_example.py
@@ -270,10 +270,10 @@ for k in range(4):
     print("would leave you with", len(accepted_m12[0]), "out of", numEvents, "events")
 
 print(accepted_m12[0])
-plt.figure()
-plt.hist(accepted_m12[0], bins=100)
-# plt.savefig('amp4body_amplitude_plots/siggen_example_m12.png')
-plt.savefig("amp4body_td_amplitude_plots/siggen_example_m12.png")
+# plt.figure()
+# plt.hist(accepted_m12[0], bins=100)
+# # plt.savefig('amp4body_amplitude_plots/siggen_example_m12.png')
+# plt.savefig("amp4body_td_amplitude_plots/siggen_example_m12.png")
 
 
 def plot_multi_body_resonance(amplitude, index):


### PR DESCRIPTION
Fixes a bug causing out of bounds memory accesses in the python binding for `GenerateSig` in `Amp4Body_TD`.