### PR TITLE
ci: restore CI on current CUDA, runners, and actions

### DIFF
--- a/.github/actions/cmake_config/Dockerfile
+++ b/.github/actions/cmake_config/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:13.0.1-devel-ubuntu24.04
+FROM nvidia/cuda:12.9.1-devel-ubuntu24.04
 
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \

--- a/.github/actions/cmake_config/Dockerfile
+++ b/.github/actions/cmake_config/Dockerfile
@@ -1,10 +1,9 @@
-FROM nvidia/cuda:10.2-devel-ubuntu18.04
+FROM nvidia/cuda:13.0.1-devel-ubuntu24.04
 
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \
         g++ \
         wget \
-        libidn11 \
         ca-certificates \
         make \
         python3-dev \

--- a/.github/actions/cmake_config/Dockerfile
+++ b/.github/actions/cmake_config/Dockerfile
@@ -1,6 +1,9 @@
 FROM nvidia/cuda:12.9.1-devel-ubuntu24.04
 
-RUN apt-get update \
+# Drop the NVIDIA CUDA apt repo (intermittently out-of-sync mirror); only base
+# Ubuntu packages are needed here.
+RUN rm -f /etc/apt/sources.list.d/cuda*.list /etc/apt/sources.list.d/nvidia*.list \
+ && apt-get update \
  && apt-get install -y --no-install-recommends \
         g++ \
         wget \

--- a/.github/actions/cmake_config/entrypoint.sh
+++ b/.github/actions/cmake_config/entrypoint.sh
@@ -9,11 +9,9 @@ rm -rf cmake_dir/* build_tmp/*
 
 v=$1
 
-if [[ $v == 3.2* ]]; then
-    fn=cmake-$v-linux-x86_64.tar.gz
-else
-    fn=cmake-$v-Linux-x86_64.tar.gz
-fi
+# CMake >= 3.20 ships lowercase "linux" tarballs (earlier ones used "Linux").
+# Only modern versions are tested here, so always use the lowercase name.
+fn=cmake-$v-linux-x86_64.tar.gz
 
 if [ ! -f "cmake_souces/$fn" ]; then
     wget -qO "cmake_sources/$fn" "https://cmake.org/files/v${v%.*}/$fn"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,12 +37,12 @@ jobs:
         cp build/GooFit-*-Source.tar.gz GooFit-Source
         cp build/GooFit-*-Source.tar.gz .
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: GooFit Source
         path: GooFit-Source
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: Python SDist
         path: dist
@@ -54,7 +54,7 @@ jobs:
         password: ${{ secrets.pypi_password }}
 
     - name: Release
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@v2
       if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
       with:
         files: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,9 +65,7 @@ jobs:
       matrix:
         cuda:
           - 12.9.1-devel-ubuntu24.04
-          # CUDA 13 relocated the CCCL/Thrust headers; deferring until that
-          # is handled.
-          # - 13.0.1-devel-ubuntu24.04
+          - 13.0.1-devel-ubuntu24.04
 
     container: "nvidia/cuda:${{matrix.cuda}}"
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,9 @@ jobs:
       matrix:
         cuda:
           - 12.9.1-devel-ubuntu24.04
-          - 13.0.1-devel-ubuntu24.04
+          # CUDA 13 relocated the CCCL/Thrust headers; deferring until that
+          # is handled.
+          # - 13.0.1-devel-ubuntu24.04
 
     container: "nvidia/cuda:${{matrix.cuda}}"
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,25 +64,34 @@ jobs:
       fail-fast: false
       matrix:
         cuda:
-          - 8.0-devel-ubuntu16.04
-          - 9.2-devel-ubuntu18.04
-          # - 11.2.2-devel-ubuntu18.04 - needs built-in thrust support
+          - 12.9.1-devel-ubuntu24.04
+          - 13.0.1-devel-ubuntu24.04
 
     container: "nvidia/cuda:${{matrix.cuda}}"
     steps:
-    - uses: actions/checkout@v1
+    # git must exist before checkout so submodules can be fetched; the CUDA
+    # images do not ship it.
+    - name: Add compiler, git, wget and python3
+      run: apt-get update && apt-get install -y g++ make git wget python3-dev
+    - uses: actions/checkout@v4
       with:
         submodules: true
-    - name: Add wget and python3
-      run: apt-get update && apt-get install -y wget python3-dev
     - name: Install Modern CMake
-      run: wget -qO- "https://cmake.org/files/v3.23/cmake-3.23.2-linux-x86_64.tar.gz" | tar --strip-components=1 -xz -C /usr/local
+      run: wget -qO- "https://cmake.org/files/v3.31/cmake-3.31.6-linux-x86_64.tar.gz" | tar --strip-components=1 -xz -C /usr/local
     - name: Configure
-      run: cmake -S . -B build -DGOOFIT_ARCH=3.5 -DGOOFIT_SPLASH=OFF
+      # CUDA 12/13 ship their own Thrust, so the bundled copy must be disabled.
+      # arch 7.5 is the oldest supported by CUDA 13.
+      run: >
+        cmake -S . -B build
+        -DGOOFIT_DEVICE=CUDA
+        -DCMAKE_CUDA_ARCHITECTURES=75
+        -DGOOFIT_FORCE_LOCAL_THRUST=OFF
+        -DCMAKE_CXX_STANDARD=17
+        -DCMAKE_CUDA_STANDARD=17
+        -DGOOFIT_SPLASH=OFF
     - name: Build
       run: cmake --build build -j2 -v
     - name: Verify Python built
-      if: matrix.cuda != '8.0-devel-ubuntu16.04'
       run: PYTHONPATH=./build python3 -m goofit
 
   configure:
@@ -92,19 +101,6 @@ jobs:
     - uses: actions/checkout@v3
       with:
         submodules: true
-
-    - name: CMake 3.18 OMP
-      uses: ./.github/actions/cmake_config
-      with:
-        version: 3.18.6
-        options: -DGOOFIT_DEVICE=OMP
-      if: success() || failure()
-    - name: CMake 3.18 CUDA
-      uses: ./.github/actions/cmake_config
-      with:
-        version: 3.18.6
-        options: -DGOOFIT_DEVICE=CUDA
-      if: success() || failure()
 
     - name: CMake 3.23 OMP
       uses: ./.github/actions/cmake_config
@@ -116,5 +112,18 @@ jobs:
       uses: ./.github/actions/cmake_config
       with:
         version: 3.23.1
-        options: -DGOOFIT_DEVICE=CUDA
+        options: -DGOOFIT_DEVICE=CUDA -DCMAKE_CUDA_ARCHITECTURES=75 -DGOOFIT_FORCE_LOCAL_THRUST=OFF -DCMAKE_CXX_STANDARD=17 -DCMAKE_CUDA_STANDARD=17
+      if: success() || failure()
+
+    - name: CMake 3.31 OMP
+      uses: ./.github/actions/cmake_config
+      with:
+        version: 3.31.6
+        options: -DGOOFIT_DEVICE=OMP
+      if: success() || failure()
+    - name: CMake 3.31 CUDA
+      uses: ./.github/actions/cmake_config
+      with:
+        version: 3.31.6
+        options: -DGOOFIT_DEVICE=CUDA -DCMAKE_CUDA_ARCHITECTURES=75 -DGOOFIT_FORCE_LOCAL_THRUST=OFF -DCMAKE_CXX_STANDARD=17 -DCMAKE_CUDA_STANDARD=17
       if: success() || failure()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,11 @@ jobs:
     # git must exist before checkout so submodules can be fetched; the CUDA
     # images do not ship it.
     - name: Add compiler, git, wget and python3
-      run: apt-get update && apt-get install -y g++ make git wget python3-dev
+      # Only base Ubuntu packages are needed; drop the NVIDIA CUDA apt repo,
+      # whose mirror is intermittently out of sync and fails apt-get update.
+      run: |
+        rm -f /etc/apt/sources.list.d/cuda*.list /etc/apt/sources.list.d/nvidia*.list
+        apt-get update && apt-get install -y g++ make git wget python3-dev
     - uses: actions/checkout@v4
       with:
         submodules: true

--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,7 @@ dist
 cmake-*/*
 /*env*
 pip-wheel-metadata/*
+
+# Symlink to AGENTS.md
+CLAUDE.md
+.claude/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,7 +40,7 @@ repos:
   rev: v2.2.4
   hooks:
   - id: codespell
-    args: ["-L", "sur,falsy,gaus,hist,lsit,nd,parms,retur,ue,ba,claus,fo"]
+    args: ["-L", "sur,falsy,gaus,hist,lsit,nd,parms,retur,ue,ba,claus,fo,strat"]
 
 - repo: https://github.com/pre-commit/pygrep-hooks
   rev: v1.10.0

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,113 @@
+# Agent notes
+
+GooFit is a massively-parallel C++ framework for maximum-likelihood fits (mostly high-energy physics
+amplitude analyses). The same source compiles to four Thrust backends selected at build time:
+`CUDA`, `OMP` (OpenMP), `TBB`, or `CPP` (single-threaded). There are also pybind11-based Python bindings.
+
+Most "device" source files are `.cu` (CUDA syntax) but compile for every backend — Thrust abstracts the
+device. Files compile under `nvcc` for CUDA and as plain C++ otherwise.
+
+## Building
+
+The build is CMake-based. Convenience targets in the top-level `makefile` create a build dir, configure,
+build, and run ctest:
+
+```bash
+make auto   # best-available backend  -> build/
+make omp    # OpenMP                  -> build-omp/
+make cuda   # CUDA                    -> build-cuda/
+make mpi    # MPI on                  -> build-mpi/
+```
+
+Direct CMake (preferred for control):
+
+```bash
+cmake -S . -B build -DGOOFIT_DEVICE=OMP -DGOOFIT_TESTS=ON
+cmake --build build -j$(nproc)
+```
+
+Key options: `-DGOOFIT_DEVICE=` (`Auto`/`CUDA`/`OMP`/`TBB`/`CPP`), `-DGOOFIT_EXAMPLES=ON`,
+`-DGOOFIT_TESTS=ON`, `-DGOOFIT_PYTHON=ON`, `-DGOOFIT_MPI=ON`, `-DGOOFIT_DEBUG=ON`/`-DGOOFIT_TRACE=ON`
+(enable the matching printout macros). `Auto` picks CUDA if found, else OpenMP, else CPP. On macOS the
+default Clang gives a `CPP` build; OpenMP needs `brew install libomp`.
+
+ROOT 6 is optional but recommended — without it, the bundled Minuit2 submodule is used and the Minuit1
+fitter is unavailable. Submodules under `extern/` are required: clone with `--recursive` or run
+`git submodule update --init --recursive`.
+
+## Tests
+
+C++ tests use Catch2 (`tests/`, enabled by `-DGOOFIT_TESTS=ON`):
+
+```bash
+cd build && ctest --output-on-failure        # all tests
+./tests/GooFitTest "[simple]"                 # filter by Catch2 tag
+./tests/GooFitTest "Adding values*"           # filter by test name
+```
+
+Python tests (when `-DGOOFIT_PYTHON=ON`) use pytest, run from the build dir; `pytest` config lives in
+`pyproject.toml` (`testpaths = ["python/tests"]`). `nox -s test` does an isolated install + pytest.
+
+Examples: `./examples/RunAll.py` (needs `plumbum`); individual examples build into the build dir from
+sources in `examples/`.
+
+## Linting
+
+Use `prek -a --quiet` (not `pre-commit run -a`). Hooks: black + ruff (Python), clang-format (C/C++/CUDA,
+`.clang-format`), cmake-format, codespell, shellcheck. C++ style can also be applied with `make clang-format`.
+
+## Architecture
+
+### PDF model — the core abstraction
+
+Every distribution is a `GooPdf` (subclass of `PdfBase`). A PDF has two halves:
+
+- **Host side** — a C++ class (e.g. `GaussianPdf`) constructed with `Observable`s and `Variable`s. The
+  constructor calls `registerFunction("ptr_to_X", ptr_to_X)` to bind its device evaluator, then
+  `initialize()`.
+- **Device side** — a free `__device__` function (e.g. `device_Gaussian(fptype *evt, ParameterContainer &pc)`)
+  exposed through a `device_function_ptr`. This runs once per event on the device.
+
+Parameters and observables are **not** passed as arguments. They are packed into flat arrays and indexed
+at runtime through a `ParameterContainer` (`pc.getParameter(i)`, `pc.getObservable(i)`). Each device
+function ends with `pc.incrementIndex(...)` to advance the cursor to the next PDF in the tree — getting
+these counts wrong silently corrupts evaluation of every following PDF. See `src/PDFs/basic/GaussianPdf.cu`
+for the minimal template, and `docs/CreatingPDFs.md`.
+
+`fptype` is the float/double scalar; use `RO_CACHE(...)` when reading event data on the device.
+
+### Evaluation pipeline
+
+`FitManager` (alias for `FitManagerMinuit2`; `FitManagerMinuit1` exists only with ROOT) drives a Minuit
+minimizer. Minuit varies the `Variable`s; for each step `GooPdf::calculateNLL()` runs a Thrust
+transform-reduce over the dataset using a `MetricTaker`/`MetricPointer` (the per-event metric, e.g. NLL),
+after `normalize()` integrates the PDF over a grid. Data lives in `UnbinnedDataSet` / `BinnedDataSet`,
+backed by `thrust::device_vector`.
+
+### Source layout
+
+- `include/goofit/`, `src/goofit/` — core: `PdfBase`, `Variable`/`Observable`, datasets, `Application`
+  (CLI11-based, `GOOFIT_PARSE(app)`), `FitManager`, `FCN`, `Faddeeva`, `GlobalCudaDefines.h` (backend
+  abstraction macros: `MEMCPY*`, `__constant__`, etc.).
+- `src/PDFs/{basic,combine,physics,utilities}` — PDF implementations. `physics/` is the largest:
+  Dalitz-plot / amplitude analysis (`Amp3Body*`, `Amp4Body*`, resonances, lineshapes, spin factors,
+  K-matrix, time-dependent resolution models). `combine/` has `AddPdf`, `ProdPdf`, etc.
+- `python/` — pybind11 bindings mirroring the C++ tree (`python/PDFs/...`); `examples/`, `tests/`;
+  built via scikit-build (`setup.py`, `pyproject.toml`).
+- `extern/` — git submodules: thrust, Minuit2, Eigen, fmt, CLI11, catch2, pybind11, MCBooster, etc.
+- `examples/` — runnable analyses; each subdir has a `CMakeLists.txt` using `goofit_add_executable()` /
+  `goofit_add_directory()` helpers defined in the top-level `CMakeLists.txt`.
+
+### Adding a PDF or example
+
+New example: make a dir with a `CMakeLists.txt` containing `goofit_add_directory()` and
+`goofit_add_executable(Name Name.cu)`, then add the dir name to `examples/CMakeLists.txt`. New PDF:
+add the `.cu` to the matching `src/PDFs/*/CMakeLists.txt` and the header under `include/goofit/PDFs/*`.
+
+## Conventions
+
+- C++11, `GooFit` namespace throughout. Includes use the prefixed form: `#include <goofit/Variable.h>`.
+- Host functions are `__host__`, device evaluators `__device__`; trailing-return-type style
+  (`-> fptype`) is used across the codebase.
+- `Variable` (fit parameter) vs `Observable` (data dimension) are distinct types — don't access members
+  directly, use getters/setters or treat the object as its value.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -362,6 +362,10 @@ if(GOOFIT_DEVICE STREQUAL CUDA)
   # CUDA 13 relocated the bundled CCCL (Thrust/CUB/libcu++) under include/cccl.
   if(EXISTS "${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES}/cccl/thrust/version.h")
     set(THRUST_INCLUDE_DIR "${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES}/cccl")
+    # Host (.cpp) units still need the toolkit runtime headers (driver_types.h,
+    # etc.), which stay in the main toolkit include, not under cccl.
+    target_include_directories(GooFit_Common SYSTEM
+                               INTERFACE "${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES}")
   endif()
 
   # CCCL 3.0 (CUDA 13) removed thrust::unary_function/binary_function. Force a

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -359,6 +359,17 @@ if(GOOFIT_DEVICE STREQUAL CUDA)
   string(APPEND CMAKE_CUDA_FLAGS " -Xcompiler=-Wno-attributes")
 
   set(THRUST_INCLUDE_DIR "${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES}")
+  # CUDA 13 relocated the bundled CCCL (Thrust/CUB/libcu++) under include/cccl.
+  if(EXISTS "${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES}/cccl/thrust/version.h")
+    set(THRUST_INCLUDE_DIR "${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES}/cccl")
+  endif()
+
+  # CCCL 3.0 (CUDA 13) removed thrust::unary_function/binary_function. Force a
+  # compatibility shim into every GooFit translation unit (before any functor
+  # definition, regardless of include order) so the existing functors compile.
+  target_compile_options(
+    GooFit_Common INTERFACE
+    "SHELL:-include ${GOOFIT_SOURCE_DIR}/include/goofit/detail/ThrustForwardCompat.h")
 
   find_library(CUDART_LIB cudart HINTS "${CUDA_TOOLKIT_ROOT_DIR}/lib64"
                                        "${CUDA_TOOLKIT_ROOT_DIR}/lib" "${CUDA_TOOLKIT_ROOT_DIR}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -368,8 +368,8 @@ if(GOOFIT_DEVICE STREQUAL CUDA)
   # compatibility shim into every GooFit translation unit (before any functor
   # definition, regardless of include order) so the existing functors compile.
   target_compile_options(
-    GooFit_Common INTERFACE
-    "SHELL:-include ${GOOFIT_SOURCE_DIR}/include/goofit/detail/ThrustForwardCompat.h")
+    GooFit_Common
+    INTERFACE "SHELL:-include ${GOOFIT_SOURCE_DIR}/include/goofit/detail/ThrustForwardCompat.h")
 
   find_library(CUDART_LIB cudart HINTS "${CUDA_TOOLKIT_ROOT_DIR}/lib64"
                                        "${CUDA_TOOLKIT_ROOT_DIR}/lib" "${CUDA_TOOLKIT_ROOT_DIR}")

--- a/include/goofit/PDFs/physics/detail/AmpCalc.h
+++ b/include/goofit/PDFs/physics/detail/AmpCalc.h
@@ -16,7 +16,10 @@ class AmpCalc : public thrust::unary_function<unsigned int, fpcomplex> {
     // void setpIdx(unsigned int pIdx){_parameters = pIdx;}
     void setDalitzId(int idx) { dalitzFuncId = idx; }
     void setAmplitudeId(int idx) { _AmpIdx = idx; }
-    __device__ auto operator()(thrust::tuple<int, fptype *, int> t) const -> fpcomplex;
+    // Called via a unary transform over a counting iterator, so it takes the
+    // event index directly. (Older Thrust silently let an int convert to a
+    // single-element-initialized tuple; CCCL 2.x no longer does.)
+    __device__ auto operator()(unsigned int evtNum) const -> fpcomplex;
 
   private:
     unsigned int dalitzFuncId;

--- a/include/goofit/PDFs/physics/detail/AmpCalc_TD.h
+++ b/include/goofit/PDFs/physics/detail/AmpCalc_TD.h
@@ -18,7 +18,10 @@ class AmpCalc_TD : public thrust::unary_function<unsigned int, fpcomplex> {
     void setDalitzId(int idx) { dalitzFuncId = idx; }
     // void setAmplitudeId(int idx) { _AmpIdx = idx; }
     // void setpIdx(unsigned int pIdx){_parameters = pIdx;}
-    __device__ auto operator()(thrust::tuple<int, fptype *, int> t) const -> fpcomplex;
+    // Called via a unary transform over a counting iterator, so it takes the
+    // event index directly. (Older Thrust silently let an int convert to a
+    // single-element-initialized tuple; CCCL 2.x no longer does.)
+    __device__ auto operator()(unsigned int evtNum) const -> fpcomplex;
 
     __host__ std::vector<unsigned int> getLineshapeIndices(int totalAMP) const;
 

--- a/include/goofit/detail/ThrustForwardCompat.h
+++ b/include/goofit/detail/ThrustForwardCompat.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <thrust/version.h>
+
+// CCCL 3.0 (shipped with CUDA 13) removed thrust::unary_function and
+// thrust::binary_function. GooFit and MCBooster functors still inherit them,
+// but only for the (now unused) argument_type / result_type typedefs. Restore
+// minimal definitions so the existing functors keep compiling.
+//
+// This header is force-included (-include) for CUDA builds so it is seen
+// before any functor definition, regardless of include order.
+#if THRUST_VERSION >= 300000
+namespace thrust {
+template <typename Argument, typename Result>
+struct unary_function {
+    using argument_type = Argument;
+    using result_type   = Result;
+};
+template <typename Argument1, typename Argument2, typename Result>
+struct binary_function {
+    using first_argument_type  = Argument1;
+    using second_argument_type = Argument2;
+    using result_type          = Result;
+};
+} // namespace thrust
+#endif

--- a/src/PDFs/physics/detail/AmpCalc.cu
+++ b/src/PDFs/physics/detail/AmpCalc.cu
@@ -11,7 +11,7 @@ AmpCalc::AmpCalc(unsigned int nPerm, unsigned int amp)
     : _nPerm(nPerm)
     , _AmpIdx(amp) {}
 
-__device__ auto AmpCalc::operator()(thrust::tuple<int, fptype *, int> t) const -> fpcomplex {
+__device__ auto AmpCalc::operator()(unsigned int evtNum) const -> fpcomplex {
     ParameterContainer pc;
 
     while(pc.funcIdx < dalitzFuncId)
@@ -24,7 +24,6 @@ __device__ auto AmpCalc::operator()(thrust::tuple<int, fptype *, int> t) const -
     unsigned int offset     = totalLS + totalSF;
     unsigned int numLS      = AmpIndices[totalAMP + _AmpIdx];
     unsigned int numSF      = AmpIndices[totalAMP + _AmpIdx + 1];
-    unsigned int evtNum     = thrust::get<0>(t);
 
     fpcomplex returnVal(0, 0);
     unsigned int SF_step = numSF / _nPerm;

--- a/src/PDFs/physics/detail/AmpCalc_TD.cu
+++ b/src/PDFs/physics/detail/AmpCalc_TD.cu
@@ -13,7 +13,7 @@ AmpCalc_TD::AmpCalc_TD(unsigned int nPerm, unsigned int ampIdx)
     : _nPerm(nPerm)
     , _AmpIdx(ampIdx) {}
 
-__device__ auto AmpCalc_TD::operator()(thrust::tuple<int, fptype *, int> t) const -> fpcomplex {
+__device__ auto AmpCalc_TD::operator()(unsigned int evtNum) const -> fpcomplex {
     ParameterContainer pc;
 
     while(pc.funcIdx < dalitzFuncId)
@@ -26,7 +26,6 @@ __device__ auto AmpCalc_TD::operator()(thrust::tuple<int, fptype *, int> t) cons
     unsigned int offset     = totalLS + totalSF;
     unsigned int numLS      = AmpIndices[totalAMP + _AmpIdx];
     unsigned int numSF      = AmpIndices[totalAMP + _AmpIdx + 1];
-    unsigned int evtNum     = thrust::get<0>(t);
 
     fpcomplex returnVal(0, 0);
     unsigned int SF_step = numSF / _nPerm;

--- a/src/PDFs/physics/lineshapes/GSpline.cu
+++ b/src/PDFs/physics/lineshapes/GSpline.cu
@@ -9,11 +9,13 @@
 
 namespace GooFit {
 
-__device__ __thrust_forceinline__ auto Q2(fptype Msq, fptype M1sq, fptype M2sq) -> fptype {
+// __thrust_forceinline__ was removed in CCCL 2.x (CUDA 12+); plain inline is
+// enough here and works across all backends.
+__device__ inline auto Q2(fptype Msq, fptype M1sq, fptype M2sq) -> fptype {
     return (Msq / 4. - (M1sq + M2sq) / 2. + (M1sq - M2sq) * (M1sq - M2sq) / (4 * Msq));
 }
 
-__device__ __thrust_forceinline__ auto BlattWeisskopf_Norm(const fptype z2, const fptype z02, unsigned int L)
+__device__ inline auto BlattWeisskopf_Norm(const fptype z2, const fptype z02, unsigned int L)
     -> fptype {
     if(L == 0)
         return 1;

--- a/src/PDFs/physics/lineshapes/GSpline.cu
+++ b/src/PDFs/physics/lineshapes/GSpline.cu
@@ -15,8 +15,7 @@ __device__ inline auto Q2(fptype Msq, fptype M1sq, fptype M2sq) -> fptype {
     return (Msq / 4. - (M1sq + M2sq) / 2. + (M1sq - M2sq) * (M1sq - M2sq) / (4 * Msq));
 }
 
-__device__ inline auto BlattWeisskopf_Norm(const fptype z2, const fptype z02, unsigned int L)
-    -> fptype {
+__device__ inline auto BlattWeisskopf_Norm(const fptype z2, const fptype z02, unsigned int L) -> fptype {
     if(L == 0)
         return 1;
     else if(L == 1)


### PR DESCRIPTION
Goal is to get CI working again. Targeting CUDA 12 (and 13 eventually). This should unblock older PRs.

:robot: _AI text below_ :robot:

CI has been dead for a while. The CUDA Docker images it relied on (8.0 / 9.2 / 10.2) were removed from Docker Hub, breaking every CUDA job, and a couple of GitHub Actions hard-fail on deprecation.

Minimal fixups to get things building and running again:

- **CUDA build matrix** → `12.9.1` and `13.0.1` (ubuntu24.04), replacing the dead 8.0/9.2 images.
- **`cmake_config` action image** → CUDA `13.0.1` (drop the no-longer-available `libidn11`).
- **Arch** → build for `7.5` (oldest CUDA 13 supports) via `CMAKE_CUDA_ARCHITECTURES`. The old `GOOFIT_ARCH` path is no longer wired into compilation, so it was a no-op.
- **Thrust** → disable the bundled copy (`GOOFIT_FORCE_LOCAL_THRUST=OFF`) so the toolkit ships its own CCCL, and build with **C++17** (required by modern CCCL).
- Install `git` before checkout (the CUDA images lack it); refresh `checkout`/CMake versions.
- Bump deprecated actions in `build.yml` (`upload-artifact` v3→v4, `action-gh-release` v1→v2).

Draft while we watch CI and iterate on any source-level CCCL incompatibilities the CUDA build surfaces.