### PR TITLE
fix: correct device index-cursor and data-pointer corruption in amplitude PDFs

### DIFF
--- a/src/PDFs/physics/Amp3Body.cu
+++ b/src/PDFs/physics/Amp3Body.cu
@@ -301,9 +301,7 @@ __host__ auto Amp3Body::normalize() -> fptype {
 #else
             thrust::transform(
                 thrust::make_zip_iterator(thrust::make_tuple(eventIndex, dataArray, eventSize)),
-                // was this correct before?
-                // thrust::make_zip_iterator(thrust::make_tuple(eventIndex + numEntries, dataArray, eventSize)),
-                thrust::make_zip_iterator(thrust::make_tuple(eventIndex + numEntries, arrayAddress, eventSize)),
+                thrust::make_zip_iterator(thrust::make_tuple(eventIndex + numEntries, dataArray, eventSize)),
                 strided_range<thrust::device_vector<fpcomplex>::iterator>(
                     cachedWaves[i]->begin(), cachedWaves[i]->end(), 1)
                     .begin(),
@@ -369,8 +367,7 @@ __host__ auto Amp3Body::sumCachedWave(size_t i) const -> fpcomplex {
 }
 
 __host__ auto Amp3Body::getCachedWave(size_t i) const -> const std::vector<std::complex<fptype>> {
-    // TODO: This calls itself immediately ?
-    auto ret_thrust = getCachedWave(i);
+    const auto &ret_thrust = getCachedWaveNoCopy(i);
     std::vector<std::complex<fptype>> ret(ret_thrust.size());
     thrust::copy(ret_thrust.begin(), ret_thrust.end(), ret.begin());
     return ret;

--- a/src/PDFs/physics/lineshapes/BW.cu
+++ b/src/PDFs/physics/lineshapes/BW.cu
@@ -142,7 +142,6 @@ __device__ auto lass_MINT(fptype Mpair, fptype m1, fptype m2, ParameterContainer
     fpcomplex BG        = SF / den;
     fpcomplex returnVal = BG + phaseshift * BW(Mpair, m1, m2, pc);
 
-    pc.incrementIndex(1, 2, 4, 0, 1);
     // The call to BW does the increment for us
 
     return returnVal;

--- a/src/PDFs/physics/resonances/Spline.cu
+++ b/src/PDFs/physics/resonances/Spline.cu
@@ -74,6 +74,11 @@ __device__ auto cubicspline(fptype m12, fptype m13, fptype m23, ParameterContain
         khiAB = khiAC;
         mAB   = mAC;
     }
+
+    // Registered: 2*nKnobs parameters (real/imag per knob), 3 + nKnobs constants
+    // (cyclic_index, doSwap, nKnobs, then nKnobs bin limits), and one normalization.
+    pc.incrementIndex(1, 2 * nKnobs, 3 + nKnobs, 0, 1);
+
     return ret;
 }
 


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Fixes four silent-corruption bugs in the physics PDFs. Each derails evaluation without raising an error, because device functions index into flat parameter/observable arrays via a shared cursor — a wrong count or pointer corrupts every following PDF.

### Changes

- **`Amp3Body` non-MPI resonance cache reads the wrong buffer.** The caching `thrust::transform` passed `arrayAddress` (the 6-element `dalitzNormRange` grid buffer) as the per-event data pointer, but `SpecialResonanceCalculator` reads event coordinates (`evt[id_m12]`/`evt[id_m13]`) from it. The MPI branch already used `dataArray`, and a commented-out line showed the non-MPI path used to as well. `arrayAddress` remains correct for the integrator grid loop. → use `dataArray`.
- **`Amp3Body::getCachedWave` infinite recursion.** It called itself instead of `getCachedWaveNoCopy` (its own `TODO` flagged this).
- **`lass_MINT` double increment.** It calls `BW()` (which increments the cursor) and then incremented again; the adjacent comment confirms the second call is the bug.
- **`Spline` resonance missing `incrementIndex`.** `cubicspline` never advanced the cursor; every sibling resonance does. Added `incrementIndex(1, 2*nKnobs, 3 + nKnobs, 0, 1)` matching its registrations.

### Testing

`PDFPhysics` compiles clean (OMP backend). `BWTest`, `ConvolutionTest`, `KinLimitBWTest`, and `dalitz_Example` pass.

These were found during a broad code review.