### PR TITLE
fix: parenthesize Flatte denominator (operator precedence)

### DIFF
--- a/src/PDFs/physics/lineshapes/Flatte.cu
+++ b/src/PDFs/physics/lineshapes/Flatte.cu
@@ -42,7 +42,8 @@ __device__ auto Flatte_MINT(fptype Mpair, fptype m1, fptype m2, ParameterContain
     // FlatteWidth.imag, Mpair, pABSq);
 
     frFactor     = BL2(pABSq * meson_radius * meson_radius, orbital);
-    fpcomplex BW = sqrt(frFactor) / fpcomplex(resmass * resmass - rMass2, 0) - fpcomplex(0, 1) * resmass * FlatteWidth;
+    fpcomplex BW
+        = sqrt(frFactor) / (fpcomplex(resmass * resmass - rMass2, 0) - fpcomplex(0, 1) * resmass * FlatteWidth);
 
     pc.incrementIndex(1, 1, 3, 0, 1);
     return BW;

--- a/src/PDFs/physics/lineshapes/Flatte.cu
+++ b/src/PDFs/physics/lineshapes/Flatte.cu
@@ -41,7 +41,7 @@ __device__ auto Flatte_MINT(fptype Mpair, fptype m1, fptype m2, ParameterContain
     // printf("%.5g %.5g %.5g %.5g %.5g %.5g %.5g %.5g \n",Gpipi.real, Gpipi.imag, GKK.real, GKK.imag, FlatteWidth.real,
     // FlatteWidth.imag, Mpair, pABSq);
 
-    frFactor     = BL2(pABSq * meson_radius * meson_radius, orbital);
+    frFactor = BL2(pABSq * meson_radius * meson_radius, orbital);
     fpcomplex BW
         = sqrt(frFactor) / (fpcomplex(resmass * resmass - rMass2, 0) - fpcomplex(0, 1) * resmass * FlatteWidth);
 


### PR DESCRIPTION
:robot: _AI text below_ :robot:

The Flatte lineshape amplitude should be `form_factor / (m0² − m² − i·m0·Width)`, but the code was:

```cpp
fpcomplex BW = sqrt(frFactor) / fpcomplex(resmass*resmass - rMass2, 0) - fpcomplex(0,1)*resmass*FlatteWidth;
```

which parses as `(num / Re) − i·m0·Width` rather than `num / (Re − i·m0·Width)` — only the real part ends up in the denominator, so the amplitude is wrong. This wraps the full complex denominator in parentheses.

`PDFPhysics` compiles clean (OMP backend). Found during a broad code review.