### PR TITLE
perf: avoid per-event device heap allocation in CompositePdf

### DIFF
--- a/src/PDFs/combine/CompositePdf.cu
+++ b/src/PDFs/combine/CompositePdf.cu
@@ -21,15 +21,14 @@ __device__ fptype device_Composite(fptype *evt, ParameterContainer &pc) {
     // int obs = pc.constants[pc.constantIdx + 1];
     int id = pc.getObservable(0);
 
-    auto *fakeEvt = new fptype[10]; // Allow plenty of space in case events are large.
-    fakeEvt[id]   = coreValue;
+    fptype fakeEvt[10]; // Allow plenty of space in case events are large.
+    fakeEvt[id] = coreValue;
 
     // Don't normalize shell either, since we don't know what composite function is being used for.
     // It may not be a PDF. Normalizing at this stage would be presumptuous.
     // fptype ret = (*(reinterpret_cast<device_function_ptr>(d_function_table[shellFcnIndex])))(fakeEvt, cudaArray,
     // shellParams);
     fptype ret = callFunction(fakeEvt, pc);
-    delete[] fakeEvt;
 
     // if (0 == THREADIDX)
     // printf("Composite: %f %f %f %f %f %f\n", evt[4], evt[5], evt[6], evt[7], coreValue, ret);


### PR DESCRIPTION
:robot: _AI text below_ :robot:

`device_Composite` ran `new fptype[10]` / `delete[]` **per event** on the device. Device-side dynamic allocation serializes on the global device heap and can exhaust it (returning `nullptr` and crashing) at realistic event counts. This replaces it with a fixed-size stack array.

Behavior is identical: only `fakeEvt[id]` is written before the shell `callFunction`, exactly as before — the array contents were already otherwise-uninitialized in both versions.

`CompositeTest` passes (OMP backend). Found during a broad code review.