### PR TITLE
fix: add missing keep_alive to prevent dangling PDF/dataset references

### DIFF
--- a/python/PDFs/combine/AddPdf.cpp
+++ b/python/PDFs/combine/AddPdf.cpp
@@ -14,7 +14,8 @@ void init_AddPdf(py::module &m) {
              AddPdf_docs.c_str(),
              "name"_a,
              "weights"_a,
-             "comps"_a)
+             "comps"_a,
+             py::keep_alive<1, 4>())
 
         .def(py::init<std::string, Variable, PdfBase *, PdfBase *>(),
              AddPdf_docs.c_str(),

--- a/python/PDFs/combine/EventWeightedAddPdf.cpp
+++ b/python/PDFs/combine/EventWeightedAddPdf.cpp
@@ -14,7 +14,8 @@ void init_EventWeightedAddPdf(py::module &m) {
              EventWeightedAddPdf_docs.c_str(),
              "name"_a,
              "weights"_a,
-             "comps"_a)
+             "comps"_a,
+             py::keep_alive<1, 4>())
 
         .def_static("help", []() { return HelpPrinter(EventWeightedAddPdf_docs); })
 

--- a/python/PDFs/combine/ProdPdf.cpp
+++ b/python/PDFs/combine/ProdPdf.cpp
@@ -10,7 +10,11 @@ using namespace GooFit;
 
 void init_ProdPdf(py::module &m) {
     py::class_<ProdPdf, CombinePdf>(m, "ProdPdf")
-        .def(py::init<std::string, std::vector<PdfBase *>>(), ProdPdf_docs.c_str(), "name"_a, "comps"_a)
+        .def(py::init<std::string, std::vector<PdfBase *>>(),
+             ProdPdf_docs.c_str(),
+             "name"_a,
+             "comps"_a,
+             py::keep_alive<1, 3>())
 
         .def_static("help", []() { return HelpPrinter(ProdPdf_docs); })
 

--- a/python/goofit/FitManager.cpp
+++ b/python/goofit/FitManager.cpp
@@ -31,7 +31,7 @@ void init_FitManager(py::module &m) {
         ;
 
     py::class_<FitManagerMinuit2>(m, "FitManager")
-        .def(py::init<PdfBase *>())
+        .def(py::init<PdfBase *>(), py::keep_alive<1, 2>())
         .def("fit", &FitManagerMinuit2::fit, py::call_guard<py::scoped_ostream_redirect>())
         .def("getMinosErrors", &FitManagerMinuit2::getMinosErrors)
         .def("getMnScan", &FitManagerMinuit2::getMnScan)

--- a/python/goofit/PdfBase.cpp
+++ b/python/goofit/PdfBase.cpp
@@ -16,7 +16,7 @@ using namespace GooFit;
 
 void init_PdfBase(py::module &m) {
     py::class_<PdfBase>(m, "PdfBase")
-        .def("setData", (void (PdfBase::*)(DataSet *))&PdfBase::setData, "ptr"_a = nullptr)
+        .def("setData", (void (PdfBase::*)(DataSet *))&PdfBase::setData, "ptr"_a = nullptr, py::keep_alive<1, 2>())
         .def("getData", &PdfBase::getData)
         .def("getName", &PdfBase::getName)
         .def("getParameters", &PdfBase::getParameters)


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Several pybind11 bindings store raw pointers to Python-owned objects for the lifetime of the C++ object, but did not tie the lifetimes together with `py::keep_alive`. Python could therefore garbage-collect a still-referenced component or dataset, leaving the C++ side with a dangling pointer (use-after-free during `setData`/`fit`).

### Changes
- **`ProdPdf`**, **`EventWeightedAddPdf`** — keep the component vector alive (`keep_alive<1,3>` / `<1,4>`).
- **`AddPdf`** — the `(weights, comps)` vector overload had no `keep_alive`, even though the `(frac, func1, func2)` overload already did. Added `keep_alive<1,4>`.
- **`FitManager(PdfBase*)`** — keep the PDF alive for the fit (`keep_alive<1,2>`).
- **`PdfBase::setData(DataSet*)`** — keep the dataset alive while attached (`keep_alive<1,2>`).

Indices follow the existing working pattern in `CompositePdf`/`MappedPdf`: nurse 1 is the bound object, patient is the relevant argument.

### Testing
The `_goofit` core extension (all five edited files) compiles and links cleanly with `-DGOOFIT_PYTHON=ON` (OMP backend). Note: a full-package import in my environment is blocked by a **pre-existing**, unrelated build error in the Minuit2 bindings (`MnMigrad` constructor mismatch against the installed ROOT) — not touched by this PR. Found during a broad code review.