### PR TITLE
fix: support ROOT 6.34+ Minuit2 MnMigrad in Python bindings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,38 @@ jobs:
         CTEST_OUTPUT_ON_FAILURE: true
         GTEST_COLOR: true
 
+  python:
+    name: OMP / Python
+    runs-on: ubuntu-latest
+    container:
+      # ROOT 6.34 reworked the Minuit2 MnMigrad constructor; build the Python
+      # bindings against it so that API break is caught here. Stay on ubuntu24.04
+      # (GCC 13): the newer ubuntu25.10 image ships GCC 15, whose libstdc++ drops
+      # std::allocator<>::reference and fails to compile the bundled thrust.
+      image: rootproject/root:6.34.00-ubuntu24.04
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
+
+    - name: Install Python dev and test tools
+      run: apt-get update && apt-get install -y python3-dev python3-numpy python3-pytest
+
+    - name: Configure
+      # ROOT 6.34 requires C++17. Only the Python bindings are needed here.
+      run: >
+        cmake -S . -B build
+        -DGOOFIT_DEVICE=OMP
+        -DGOOFIT_PYTHON=ON
+        -DGOOFIT_TESTS=OFF
+        -DGOOFIT_EXAMPLES=OFF
+        -DCMAKE_CXX_STANDARD=17
+    - name: Build
+      run: cmake --build build -j "$(getconf _NPROCESSORS_ONLN)"
+    - name: Run Python tests
+      run: PYTHONPATH="$PWD/build" python3 -m pytest python/tests -v
+
   clang-tidy:
     runs-on: ubuntu-latest
     container: silkeh/clang:15

--- a/python/Minuit2/MnMigrad.cpp
+++ b/python/Minuit2/MnMigrad.cpp
@@ -4,6 +4,7 @@
 
 #include <Minuit2/FCNBase.h>
 #include <Minuit2/MnMigrad.h>
+#include <Minuit2/MnStrategy.h>
 #include <Minuit2/MnUserParameters.h>
 
 namespace py = pybind11;
@@ -12,6 +13,13 @@ using namespace pybind11::literals;
 using namespace ROOT::Minuit2;
 
 void init_MnMigrad(py::module &m) {
+    // ROOT 6.34's Minuit2 dropped the (FCNBase, MnUserParameters, unsigned int) overload in favor of
+    // (FCNBase, MnUserParameterState, MnStrategy); construct it explicitly so both APIs are supported.
     py::class_<MnMigrad, MnApplication>(m, "MnMigrad")
-        .def(py::init<const FCNBase &, const MnUserParameters &, unsigned int>(), "fcn"_a, "par"_a, "stra"_a = 1);
+        .def(py::init([](const FCNBase &fcn, const MnUserParameters &par, unsigned int stra) {
+                 return new MnMigrad(fcn, par, MnStrategy(stra));
+             }),
+             "fcn"_a,
+             "par"_a,
+             "stra"_a = 1);
 }


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Problem

The Python bindings fail to compile against **ROOT 6.34+** (including 6.40):

```
python/Minuit2/MnMigrad.cpp:16: error: no matching constructor for
initialization of 'ROOT::Minuit2::MnMigrad'
```

ROOT 6.34 reworked Minuit2's `MnMigrad` constructor, dropping the
`(FCNBase, MnUserParameters, unsigned int)` overload in favor of
`(FCNBase, MnUserParameterState, MnStrategy)`. Since `unsigned int` does not
implicitly convert to `MnStrategy`, the templated `py::init<…, unsigned int>()`
no longer matched any overload. CI didn't catch this because the only
ROOT-based job runs 6.32 (old API) and never built the Python bindings.

## Fix

Construct `MnMigrad` through a lambda `py::init`, relying on the implicit
`MnUserParameters → MnUserParameterState` conversion and an explicit
`MnStrategy(stra)`. This compiles against both the new and old APIs (and the
bundled Minuit2 submodule); the Python API is unchanged
(`MnMigrad(fcn, par, stra=1)`).

## CI

Adds an **OMP / Python** job on `rootproject/root:6.34.00-ubuntu24.04` (which
has the new API) that builds the bindings with `-DGOOFIT_PYTHON=ON` and runs
the pytest suite, so this break is caught going forward.

The job deliberately stays on **ubuntu24.04 (GCC 13)**: the newer
`ubuntu25.10` image ships GCC 15, whose libstdc++ removed
`std::allocator<>::reference`, which the bundled thrust submodule still uses —
an unrelated pre-existing incompatibility.

## Verification

- Full build + `pytest python/tests` pass locally against **ROOT 6.40.02** (6 passed).
- Reproduced the CI job in the `rootproject/root:6.34.00-ubuntu24.04` container: build OK, **6 passed**.
- clang-format passes.