### PR TITLE
fix: normalize last component of non-extended AddPdf

### DIFF
--- a/src/PDFs/combine/AddPdf.cu
+++ b/src/PDFs/combine/AddPdf.cu
@@ -39,9 +39,10 @@ __device__ auto device_AddPdfs(fptype *evt, ParameterContainer &pc) -> fptype {
         ret += weight * curr * norm;
     }
 
-    // previous functions incremented the indices appropriately, so now we need to get the norm again
-    // NOTE: this is the weight for the function about to be called.
-    fptype normFactor = local_pc.getNormalization(0);
+    // The loop above advanced pc to the last (unweighted) component, so read *its*
+    // normalization here - not local_pc's, which points back at the AddPdf node and
+    // would leave the final component unnormalized.
+    fptype normFactor = pc.getNormalization(0);
 
     fptype last = callFunction(evt, pc);
     ret += (1 - totalWeight) * last * normFactor;

--- a/tests/simple/AddNormTest.cpp
+++ b/tests/simple/AddNormTest.cpp
@@ -1,0 +1,44 @@
+#include <goofit/Catch.h>
+
+#include <goofit/PDFs/basic/GaussianPdf.h>
+#include <goofit/PDFs/combine/AddPdf.h>
+#include <goofit/UnbinnedDataSet.h>
+
+#include <goofit/Variable.h>
+
+using namespace GooFit;
+
+// Regression test: a non-extended AddPdf f*A + (1-f)*B must normalize *every*
+// component, including the last one. Picking two Gaussians with different widths
+// makes their normalization factors differ, so a missing factor on the last term
+// is detectable. The combined probability must equal the weighted sum of the
+// (already normalized) component probabilities at every point.
+TEST_CASE("AddPdf component normalization", "[basic]") {
+    Observable xvar{"xvar", -5, 10};
+
+    Variable mean{"mean", 1.5};
+    Variable sigmaA{"sigmaA", 2.5};
+    Variable sigmaB{"sigmaB", 0.8};
+
+    GaussianPdf gaussA{"gaussA", xvar, mean, sigmaA};
+    GaussianPdf gaussB{"gaussB", xvar, mean, sigmaB};
+
+    Variable frac{"frac", 0.6};
+
+    // Non-extended two-component constructor: frac * gaussA + (1 - frac) * gaussB.
+    AddPdf sum{"sum", frac, &gaussA, &gaussB};
+
+    auto dataset = sum.makeGrid();
+    sum.setData(&dataset);
+
+    auto vv = sum.getCompProbsAtDataPoints();
+
+    REQUIRE(vv.size() == 3); // combined, gaussA, gaussB
+    REQUIRE(vv[0].size() == vv[1].size());
+    REQUIRE(vv[0].size() == vv[2].size());
+
+    const fptype f = 0.6;
+    for(size_t i = 0; i < vv[0].size(); i += 7) {
+        CHECK(vv[0][i] == Approx(f * vv[1][i] + (1 - f) * vv[2][i]));
+    }
+}

--- a/tests/simple/CMakeLists.txt
+++ b/tests/simple/CMakeLists.txt
@@ -1,5 +1,6 @@
 goofit_catch_test(VectorsTest)
 goofit_catch_test(NormalizeTest)
+goofit_catch_test(AddNormTest)
 goofit_catch_test(SimpleTest)
 goofit_catch_test(BinningTest)
 


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Problem

`device_AddPdfs` (the non-extended `f*A + (1-f)*B` path) read the final, unweighted component's normalization from `local_pc`:

```cpp
fptype normFactor = local_pc.getNormalization(0);
fptype last       = callFunction(evt, pc);
ret += (1 - totalWeight) * last * normFactor;
```

`local_pc` is the snapshot taken *before* `incrementIndex()`, so it still points at the `AddPdf` node itself, whose own normalization is hard-set to `1.0` in `AddPdf::normalize()`. The result: the last component is added **unnormalized**, while every weighted component in the loop above is correctly divided by its own normalization via `pc.getNormalization(0)`.

For two Gaussians of different width this yields `f·A/∫A + (1-f)·B` instead of `f·A/∫A + (1-f)·B/∫B`.

The weighted-component loop and `device_AddPdfsExt` both already use `pc.getNormalization(0)` (the current component, reached after the loop advanced `pc`). The tail term now does the same.

## Test

Added `tests/simple/AddNormTest.cpp`: builds a non-extended `AddPdf` of two Gaussians with different widths and checks the combined probability equals `f·probA + (1-f)·probB` at grid points. It **fails** on `master` (last term off by the missing 1/∫B factor) and passes with this change.

## Verification

OMP build. `AddNormTest`, `NormalizeTest`, `EventWeightedAddTest` pass; the `dalitz` example still fits. CUDA not built locally.