### PR TITLE
fix: two latent correctness bugs (Bernstein factorial overflow, FunctorWriter I/O mismatch)

### DIFF
--- a/src/PDFs/basic/BernsteinPdf.cu
+++ b/src/PDFs/basic/BernsteinPdf.cu
@@ -5,7 +5,8 @@
 
 namespace GooFit {
 
-__device__ auto factorial(int n) -> int {
+// Returns fptype, not int: int overflows at 13! and Bernstein degrees can exceed that.
+__device__ auto factorial(int n) -> fptype {
     if(n == 0)
         return 1;
     else

--- a/src/goofit/FunctorWriter.cpp
+++ b/src/goofit/FunctorWriter.cpp
@@ -44,10 +44,10 @@ void readFromFile(PdfBase *pdf, const char *fname) {
         Variable *var = tempMap[buffer];
 
         fptype value, error, lowerlimit, upperlimit;
-        size_t numbins;
 
         if(var) {
-            reader >> value >> error >> numbins >> lowerlimit >> upperlimit;
+            // Field order must match writeToFile(): name value error lower upper.
+            reader >> value >> error >> lowerlimit >> upperlimit;
 
             var->setValue(value);
             var->setError(error);


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Two small, independent latent correctness bugs.

## BernsteinPdf — integer factorial overflow

```cpp
__device__ auto factorial(int n) -> int { ... return n * factorial(n - 1); }
```

`int` overflows at `13! > 2^31`. `device_BernsteinPdf` evaluates the basis with `binomial(i, maxDegree - 1)`, so a Bernstein polynomial of degree ≥ 14 silently gets garbage binomial coefficients. `binomial()` already accumulates in `fptype`; this makes `factorial()` return `fptype` too.

## FunctorWriter — read/write field mismatch

`writeToFile()` writes five fields per parameter:

```
name value error lowerLimit upperLimit
```

but `readFromFile()` parsed six:

```cpp
reader >> value >> error >> numbins >> lowerlimit >> upperlimit;
```

The phantom `numbins` field shifted every subsequent read by one, so limits were mangled on round-trip. Removed it so the reader matches the writer.

## Verification

OMP build compiles cleanly. No dedicated tests exist for these paths (Bernstein has none; FunctorWriter is file I/O); changes are localized and match the corresponding producer/consumer. CUDA not built locally.