### PR TITLE
chore: modernize typedefs to using aliases and remove dead code

### DIFF
--- a/include/goofit/PDFs/MetricPointer.h
+++ b/include/goofit/PDFs/MetricPointer.h
@@ -4,7 +4,7 @@
 namespace GooFit {
 
 /// Pass event, parameters, index into parameters.
-typedef fptype (*device_metric_ptr)(fptype, fptype *, fptype);
+using device_metric_ptr = fptype (*)(fptype, fptype *, fptype);
 
 auto getMetricPointer(EvalFunc val) -> void *;
 

--- a/include/goofit/PDFs/detail/Globals.h
+++ b/include/goofit/PDFs/detail/Globals.h
@@ -9,7 +9,7 @@ namespace GooFit {
 
 struct ParameterContainer;
 
-typedef fptype (*device_function_ptr)(fptype *, ParameterContainer &);
+using device_function_ptr = fptype (*)(fptype *, ParameterContainer &);
 
 extern SmartVector<fptype> host_parameters;
 extern SmartVector<fptype> host_constants;

--- a/include/goofit/PDFs/physics/DalitzPlotHelpers.h
+++ b/include/goofit/PDFs/physics/DalitzPlotHelpers.h
@@ -183,7 +183,7 @@ typedef struct {
     fptype bi_imag;
 } WaveHolder_s;
 
-typedef thrust::tuple<fptype, fptype, fptype, fptype> WaveHolder;
-typedef thrust::tuple<fptype, fptype, fptype, fptype, fptype, fptype> ThreeComplex;
+using WaveHolder   = thrust::tuple<fptype, fptype, fptype, fptype>;
+using ThreeComplex = thrust::tuple<fptype, fptype, fptype, fptype, fptype, fptype>;
 
 } // namespace GooFit

--- a/include/goofit/PDFs/physics/MixingTimeResolution.h
+++ b/include/goofit/PDFs/physics/MixingTimeResolution.h
@@ -5,9 +5,9 @@
 
 namespace GooFit {
 
-typedef fptype (*device_resfunction_ptr)(
-    fptype, fptype, fptype, fptype, fptype, fptype, fptype, fptype, fptype, ParameterContainer &pc);
-typedef fptype (*device_calc_tau_fcn_ptr)(fptype, fptype, fptype, fptype, fptype, fptype, fptype);
+using device_resfunction_ptr
+    = fptype (*)(fptype, fptype, fptype, fptype, fptype, fptype, fptype, fptype, fptype, ParameterContainer &pc);
+using device_calc_tau_fcn_ptr = fptype (*)(fptype, fptype, fptype, fptype, fptype, fptype, fptype);
 
 /**
 The abstract base class of

--- a/include/goofit/PDFs/physics/SpinFactors.h
+++ b/include/goofit/PDFs/physics/SpinFactors.h
@@ -13,7 +13,7 @@ See *.cu file for more details
 
 namespace GooFit {
 
-typedef fptype (*spin_function_ptr)(fptype *, ParameterContainer &);
+using spin_function_ptr = fptype (*)(fptype *, ParameterContainer &);
 
 enum class SF_4Body {
     DtoPP1_PtoSP2_StoP3P4,

--- a/include/goofit/PDFs/physics/lineshapes/Lineshape.h
+++ b/include/goofit/PDFs/physics/lineshapes/Lineshape.h
@@ -47,20 +47,8 @@ class Lineshape : public AmpComponent {
     virtual std::ostream &print(std::ostream &out) const;
 
     auto operator==(const Lineshape &L) const -> bool {
-        // bool namesEqual = this->getName() == L.getName();
-        // std::cout << "Names equal? " << namesEqual << std::endl;
-
         bool typesEqual = typeid(*this) == typeid(L);
-        // std::cout << "Types equal? " << typesEqual << std::endl;
-
         bool equalByVal = this->isEqualByValue(L);
-        // std::cout << "Equal vals? " << equalByVal << std::endl;
-
-        // std::cout << "This name: " << this->getName() << std::endl;
-        // std::cout << "That name: " << L.getName() << std::endl;
-        // std::cout << "This type: " << typeid(*this).name() << std::endl;
-        // std::cout << "That type: " << typeid(L).name() << std::endl << std::endl;;
-
         return typesEqual && equalByVal;
     }
 };

--- a/include/goofit/PDFs/physics/resonances/Resonance.h
+++ b/include/goofit/PDFs/physics/resonances/Resonance.h
@@ -8,7 +8,7 @@
 
 namespace GooFit {
 
-typedef fpcomplex (*resonance_function_ptr)(fptype, fptype, fptype, ParameterContainer &pc);
+using resonance_function_ptr = fpcomplex (*)(fptype, fptype, fptype, ParameterContainer &pc);
 
 __device__ auto dh_dsFun(double s, double daug2Mass, double daug3Mass) -> fptype;
 

--- a/src/PDFs/physics/Amp4Body_TD.cu
+++ b/src/PDFs/physics/Amp4Body_TD.cu
@@ -711,7 +711,7 @@ __host__ std::vector<bool> Amp4Body_TD::areAmplitudeComponentsChanged() const {
     if(!_forceRedoIntegrals) {
         for(int a = 0; a < _NUM_AMPLITUDES; a++) {
             Amplitude *amp = dynamic_cast<Amplitude *>(components[a]);
-            if(amp == NULL) {
+            if(amp == nullptr) {
                 throw GeneralError("Error retrieving amplitude components.");
             }
 


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Low-risk cleanup, no behavior change.

## `typedef` → `using`

Converted the function-pointer and tuple typedefs in the PDF headers to `using` aliases:

| Header | Alias |
|--------|-------|
| `PDFs/detail/Globals.h` | `device_function_ptr` |
| `PDFs/MetricPointer.h` | `device_metric_ptr` |
| `PDFs/physics/MixingTimeResolution.h` | `device_resfunction_ptr`, `device_calc_tau_fcn_ptr` |
| `PDFs/physics/SpinFactors.h` | `spin_function_ptr` |
| `PDFs/physics/resonances/Resonance.h` | `resonance_function_ptr` |
| `PDFs/physics/DalitzPlotHelpers.h` | `WaveHolder`, `ThreeComplex` |

## Other

- `Amp4Body_TD.cu`: `NULL` → `nullptr`.
- `Lineshape::operator==`: removed a block of commented-out debug `std::cout` lines.

## Verification

Full OMP build compiles with no new warnings; `BWTest` passes and the `dalitz` example still runs. These headers are pulled into most `.cu` translation units, so the build exercises every changed alias. CUDA not built locally.