### PR TITLE
build: use modern CCCL for the bundled Thrust (fix #387)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,11 +43,11 @@ jobs:
     name: OMP / Python
     runs-on: ubuntu-latest
     container:
-      # ROOT 6.34 reworked the Minuit2 MnMigrad constructor; build the Python
-      # bindings against it so that API break is caught here. Stay on ubuntu24.04
-      # (GCC 13): the newer ubuntu25.10 image ships GCC 15, whose libstdc++ drops
-      # std::allocator<>::reference and fails to compile the bundled thrust.
-      image: rootproject/root:6.34.00-ubuntu24.04
+      # ROOT 6.34+ reworked the Minuit2 MnMigrad constructor; build the Python
+      # bindings against it so that API break is caught here. This image ships
+      # GCC 15 (whose libstdc++ drops std::allocator<>::reference), exercising
+      # the modern bundled CCCL on the newest toolchain.
+      image: rootproject/root:6.38.00-ubuntu25.10
 
     steps:
     - uses: actions/checkout@v4
@@ -58,7 +58,7 @@ jobs:
       run: apt-get update && apt-get install -y python3-dev python3-numpy python3-pytest
 
     - name: Configure
-      # ROOT 6.34 requires C++17. Only the Python bindings are needed here.
+      # ROOT 6.38 requires C++17. Only the Python bindings are needed here.
       run: >
         cmake -S . -B build
         -DGOOFIT_DEVICE=OMP

--- a/.gitmodules
+++ b/.gitmodules
@@ -12,7 +12,7 @@
 	url = ../../GooFit/Minuit2.git
 [submodule "extern/thrust"]
 	path = extern/thrust
-	url = ../../thrust/thrust.git
+	url = ../../NVIDIA/cccl.git
 [submodule "extern/rang"]
 	path = extern/rang
 	url = ../../agauniyal/rang.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -372,13 +372,6 @@ if(GOOFIT_DEVICE STREQUAL CUDA)
                                INTERFACE "${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES}")
   endif()
 
-  # CCCL 3.0 (CUDA 13) removed thrust::unary_function/binary_function. Force a
-  # compatibility shim into every GooFit translation unit (before any functor
-  # definition, regardless of include order) so the existing functors compile.
-  target_compile_options(
-    GooFit_Common
-    INTERFACE "SHELL:-include ${GOOFIT_SOURCE_DIR}/include/goofit/detail/ThrustForwardCompat.h")
-
   find_library(CUDART_LIB cudart HINTS "${CUDA_TOOLKIT_ROOT_DIR}/lib64"
                                        "${CUDA_TOOLKIT_ROOT_DIR}/lib" "${CUDA_TOOLKIT_ROOT_DIR}")
 
@@ -406,30 +399,46 @@ target_compile_options(
   GooFit_Common INTERFACE $<${cxx_lang_rel}:$<BUILD_INTERFACE:${GOOFIT_OPTI}>>
                           $<${cuda_lang_rel}:$<BUILD_INTERFACE:-Xcompiler=${GOOFIT_OPTI_CUDA}>>)
 
-find_package(Thrust QUIET)
-if(NOT THRUST_FOUND)
-  set(THRUST_INCLUDE_DIR "${GOOFIT_SOURCE_DIR}/extern/thrust")
-  find_package(Thrust REQUIRED)
-endif()
-
 option(GOOFIT_FORCE_LOCAL_THRUST
-       "GooFit will use the GitHub version of Thrust by default (CUDA 9 and 10's Thrust is buggy)"
-       ON)
+       "Use the bundled CCCL (Thrust/CUB/libcu++) instead of the system/toolkit copy" ON)
+
 if(GOOFIT_FORCE_LOCAL_THRUST)
-  message(
-    STATUS "Forcing local thrust. GOOFIT_FORCE_LOCAL_THRUST=OFF to disable. Requires CUDA < 10.1")
-  message(STATUS "Using CUDA from ${THRUST_INCLUDE_DIRS}")
-  target_include_directories(GooFit_Common SYSTEM BEFORE
-                             INTERFACE "${GOOFIT_SOURCE_DIR}/extern/thrust")
+  # extern/thrust is NVIDIA/CCCL: Thrust, CUB and libcu++ live in sibling
+  # subtrees, so all three include roots go on the path (CUB is only used by the
+  # CUDA backend, but adding it is harmless elsewhere).
+  set(GOOFIT_CCCL_DIR "${GOOFIT_SOURCE_DIR}/extern/thrust")
+  if(NOT EXISTS "${GOOFIT_CCCL_DIR}/thrust/thrust/version.h")
+    message(FATAL_ERROR "Bundled CCCL not found at ${GOOFIT_CCCL_DIR}. "
+                        "Run 'git submodule update --init --recursive'.")
+  endif()
+  set(THRUST_INCLUDE_DIRS "${GOOFIT_CCCL_DIR}/thrust" "${GOOFIT_CCCL_DIR}/cub"
+                          "${GOOFIT_CCCL_DIR}/libcudacxx/include")
+  message(STATUS "Using bundled CCCL (Thrust/CUB/libcu++) from ${GOOFIT_CCCL_DIR}")
   if(GOOFIT_DEVICE STREQUAL CUDA)
-    target_compile_options(GooFit_Common INTERFACE "SHELL:-isystem ${THRUST_INCLUDE_DIRS}")
+    foreach(_inc IN LISTS THRUST_INCLUDE_DIRS)
+      target_compile_options(GooFit_Common INTERFACE "SHELL:-isystem ${_inc}")
+    endforeach()
   else()
-    target_include_directories(GooFit_Common SYSTEM INTERFACE "${THRUST_INCLUDE_DIRS}")
+    target_include_directories(GooFit_Common SYSTEM BEFORE INTERFACE ${THRUST_INCLUDE_DIRS})
   endif()
 else()
+  # Use the copy that ships with the CUDA toolkit (THRUST_INCLUDE_DIR is set in
+  # the CUDA block above, accounting for the CUDA 13 cccl/ relocation).
+  find_package(Thrust QUIET)
+  if(NOT THRUST_FOUND)
+    find_package(Thrust REQUIRED)
+  endif()
   target_include_directories(GooFit_Common SYSTEM INTERFACE "${THRUST_INCLUDE_DIRS}")
   message(STATUS "Using Thrust and CUDA from ${THRUST_INCLUDE_DIRS}")
 endif()
+
+# CCCL 3.0 removed thrust::unary_function/binary_function. Force a compatibility
+# shim into every GooFit translation unit (before any functor definition,
+# regardless of include order) so the existing functors compile. The shim is
+# version-guarded, so it is inert against older Thrust (e.g. CUDA 12's CCCL 2.x).
+target_compile_options(
+  GooFit_Common
+  INTERFACE "SHELL:-include ${GOOFIT_SOURCE_DIR}/include/goofit/detail/ThrustForwardCompat.h")
 
 if(GOOFIT_DEVICE STREQUAL OMP
    OR GOOFIT_HOST STREQUAL OMP

--- a/include/goofit/GlobalCudaDefines.h
+++ b/include/goofit/GlobalCudaDefines.h
@@ -22,8 +22,16 @@ extern int host_callnumber;
 #define _Pragma(x) __pragma(x)
 #endif
 
-// Allow code to work on non-CUDA systems (beyond what is provided with thrust)
+// Allow code to work on non-CUDA systems (beyond what is provided with thrust).
+// Older Thrust defined __host__/__device__ for non-CUDA backends; modern CCCL
+// (3.x) no longer does, so define them here for plain-C++ compilation.
 #if THRUST_DEVICE_SYSTEM != THRUST_DEVICE_SYSTEM_CUDA
+#ifndef __host__
+#define __host__
+#endif
+#ifndef __device__
+#define __device__
+#endif
 #define __align__(n)
 inline void cudaDeviceSynchronize() {}
 #define __shared__

--- a/include/goofit/PDFs/MetricTaker.h
+++ b/include/goofit/PDFs/MetricTaker.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <thrust/functional.h>
+#include <thrust/tuple.h>
 
 #include <goofit/PdfBase.h>
 

--- a/include/goofit/PDFs/physics/DalitzPlotHelpers.h
+++ b/include/goofit/PDFs/physics/DalitzPlotHelpers.h
@@ -14,6 +14,7 @@ See *.cu file for more details
 
 #include <thrust/device_vector.h>
 #include <thrust/iterator/constant_iterator.h>
+#include <thrust/tuple.h>
 
 namespace GooFit {
 

--- a/include/goofit/detail/ThrustForwardCompat.h
+++ b/include/goofit/detail/ThrustForwardCompat.h
@@ -38,5 +38,12 @@ struct binary_function {
     using second_argument_type = Argument2;
     using result_type          = Result;
 };
+// thrust::identity was also dropped; a couple of examples still use it.
+template <typename T>
+struct identity {
+    using argument_type = T;
+    using result_type   = T;
+    __host__ __device__ constexpr auto operator()(const T &x) const -> T { return x; }
+};
 } // namespace thrust
 #endif

--- a/include/goofit/detail/ThrustForwardCompat.h
+++ b/include/goofit/detail/ThrustForwardCompat.h
@@ -1,14 +1,30 @@
 #pragma once
 
-#include <thrust/version.h>
+#include <thrust/detail/config.h> // THRUST_DEVICE_SYSTEM, THRUST_VERSION
+// Modern CCCL (3.x) no longer pulls thrust::tuple / thrust::get in transitively
+// through headers like <thrust/functional.h>. MCBooster (unmaintained) and some
+// GooFit headers rely on that; include it once, up front, for every unit.
+#include <thrust/tuple.h>
+
+// Older Thrust defined __host__/__device__ (to nothing) for non-CUDA backends;
+// modern CCCL (3.x) no longer does. On CUDA builds the toolkit still provides
+// them (even in host translation units), so only define them when the device
+// system is not CUDA. This header is force-included (-include) into every
+// translation unit, so the macros are seen before any MCBooster/GooFit header,
+// regardless of include order.
+#if THRUST_DEVICE_SYSTEM != THRUST_DEVICE_SYSTEM_CUDA
+#ifndef __host__
+#define __host__
+#endif
+#ifndef __device__
+#define __device__
+#endif
+#endif
 
 // CCCL 3.0 (shipped with CUDA 13) removed thrust::unary_function and
 // thrust::binary_function. GooFit and MCBooster functors still inherit them,
 // but only for the (now unused) argument_type / result_type typedefs. Restore
 // minimal definitions so the existing functors keep compiling.
-//
-// This header is force-included (-include) for CUDA builds so it is seen
-// before any functor definition, regardless of include order.
 #if THRUST_VERSION >= 300000
 namespace thrust {
 template <typename Argument, typename Result>

--- a/src/PDFs/physics/detail/SpecialResonanceCalculator.cu
+++ b/src/PDFs/physics/detail/SpecialResonanceCalculator.cu
@@ -11,7 +11,10 @@ SpecialResonanceCalculator::SpecialResonanceCalculator(int pIdx, unsigned int re
 
 __device__ auto SpecialResonanceCalculator::operator()(thrust::tuple<int, fptype *, int> t) const -> fpcomplex {
     // Calculates the BW values for a specific resonance.
-    fpcomplex ret;
+    // Zero-initialize: CCCL 3.x thrust::complex (= cuda::std::complex) has a
+    // trivial default constructor (old Thrust zeroed it). This value is returned
+    // as-is for out-of-Dalitz events, so it must be 0, not garbage.
+    fpcomplex ret(0, 0);
     int evtNum  = thrust::get<0>(t);
     fptype *evt = thrust::get<1>(t) + (evtNum * thrust::get<2>(t));
 

--- a/src/PDFs/physics/detail/SpecialResonanceIntegrator.cu
+++ b/src/PDFs/physics/detail/SpecialResonanceIntegrator.cu
@@ -18,7 +18,10 @@ __device__ auto device_DalitzPlot_calcIntegrals(fptype m12, fptype m13, int res_
     fptype daug2Mass  = c_daug2Mass;  // RO_CACHE(pc.constants[pc.constantIdx + 6]);
     fptype daug3Mass  = c_daug3Mass;  // RO_CACHE(pc.constants[pc.constantIdx + 7]);
 
-    fpcomplex ret;
+    // Zero-initialize: CCCL 3.x thrust::complex (= cuda::std::complex) has a
+    // trivial default constructor (old Thrust zeroed it). This value is returned
+    // as-is for out-of-Dalitz grid bins, so it must be 0, not garbage.
+    fpcomplex ret(0, 0);
 
     if(!inDalitz(m12, m13, motherMass, daug1Mass, daug2Mass, daug3Mass))
         return ret;


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

Fixes #387. The bundled `extern/thrust` was thrust **1.8.3** (2016), which references `std::allocator<>::reference` — deprecated in C++17 and **removed from libstdc++ in GCC 15** — so it no longer compiled on modern toolchains (e.g. `ubuntu25.10`). The CUDA backend already uses the toolkit's modern CCCL; only the host backends (OMP/CPP/TBB) were stuck on the ancient bundled copy.

This repoints the bundled submodule at **NVIDIA/CCCL v3.3.3**, unifying both Thrust paths on modern CCCL.

## Changes

- **Submodule**: `extern/thrust` → `NVIDIA/cccl` @ **v3.3.3** (`.gitmodules` URL + gitlink).
- **CMake**: the bundled (`GOOFIT_FORCE_LOCAL_THRUST=ON`) path now adds CCCL's three include roots — `thrust/`, `cub/`, `libcudacxx/include/` — with a clear missing-submodule error. The toolkit (`=OFF`) path is unchanged.
- **`ThrustForwardCompat.h`** is now force-included for *every* backend (was CUDA-only). For non-CUDA device systems it additionally defines empty `__host__`/`__device__` and includes `<thrust/tuple.h>` — modern CCCL no longer provides either transitively, which MCBooster and some GooFit headers relied on. Force-include makes this robust to header ordering.
- Explicit `<thrust/tuple.h>` added to the two GooFit headers that name `thrust::tuple`.
- **CI**: the OMP/Python job moves onto the GCC 15 image `rootproject/root:6.38.00-ubuntu25.10`, which is what now exercises this fix. OMP/Test stays on GCC 13 for compiler-version spread.

MCBooster (current pointer) needed no further changes — its existing CCCL-3 fixes plus the global shim suffice on host.

## Testing

- **CPP backend builds clean and all 31 `ctest` cases pass** locally (faithful proxy for the host Thrust path).
- `prek` hooks pass.
- **GCC 15 and CUDA are verified by CI** (could not be built locally on macOS): GCC 15 via the new OMP/Python image, CUDA via the existing CUDA jobs whose CCCL-3.x path was already green.