### PR TITLE
fix: correct higher-moment integrals in ThreeGaussResolutionExt high-T region

### DIFF
--- a/src/PDFs/physics/ThreeGaussResolutionExt.cu
+++ b/src/PDFs/physics/ThreeGaussResolutionExt.cu
@@ -153,8 +153,10 @@ __device__ void gaussian_high(fptype &_P1,
 
     fptype _Ig0 = SQRTPIo2 * erfc(u1);
     fptype _Ig1 = 0.5 * exp(-1 * u1 * u1);
-    fptype _Ig2 = _Ig1 * 1 + 0.5 * _Ig0;
-    fptype _Ig3 = _Ig1 * (u1 + 1);
+    // Moments int_{u1}^inf s^n exp(-s^2) ds: the lower limit is u1, not _u0.
+    // (cf. gaussian_low above and mygaussian_high in ThreeGaussResolutionSplice.cu.)
+    fptype _Ig2 = _Ig1 * u1 + 0.5 * _Ig0;
+    fptype _Ig3 = _Ig1 * (u1 * u1 + 1);
 
     fptype _R   = xmixing * _Gamma * _1oSqrtA;
     fptype _R2  = _R * _R;


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

`gaussian_high()` in `ThreeGaussResolutionExt.cu` computes the truncated Gaussian moment integrals $\int_{u_1}^{\infty} s^n e^{-s^2}\,ds$ for the exponential-acceptance region $t > T_\mathrm{thres}$. Two had the wrong lower limit:

```cpp
_Ig2 = _Ig1 * 1;          // should be _Ig1 * u1
_Ig3 = _Ig1 * (u1 + 1);   // should be _Ig1 * (u1*u1 + 1)
```

A dropped `u1` factor and a missing square. These feed `_It2`/`_It3` — the $O(x_\mathrm{mix}^2)$ / $O(x_\mathrm{mix}^3)$ terms of the cosine/sine convolution moments `_P2`/`_P4` — so the per-event probability was slightly wrong while the **analytically computed** normalization was not, leaving a shape/normalization inconsistency.

## Verification

The correct expressions are confirmed four independent ways:
1. **Closed form** — $\int_{u_1}^{\infty} s^2 e^{-s^2}ds = \tfrac12 u_1 e^{-u_1^2} + \tfrac{\sqrt\pi}{4}\,\mathrm{erfc}(u_1)$ and $\int_{u_1}^{\infty} s^3 e^{-s^2}ds = \tfrac12 (u_1^2+1)e^{-u_1^2}$.
2. **`gaussian2()`** (same file, no acceptance) uses lower limit `_u0`: `_Ig2 = _Ig1*_u0 + 0.5*_Ig0`, `_Ig3 = _Ig1*(_u02+1)`.
3. **`gaussian_low()`** (same file, region $0<t<T_\mathrm{thres}$) uses `u1` correctly as a limit.
4. **`mygaussian_high()`** in `ThreeGaussResolutionSplice.cu` is the corrected copy of this exact function: `_Ig2 = _Ig1*u1 + 0.5*_Ig0`, `_Ig3 = _Ig1*(u12 + 1)`.

## Testing

Builds cleanly (CPP backend). `ThreeGaussResolutionExt` has no C++ test or example (Python-binding-only), so there is no runtime regression to add here; the fix is a textbook moment-integral correction matching the sibling implementation.