### PR TITLE
fix: correct natural-cubic-spline curvature setup in GSpline

### DIFF
--- a/src/PDFs/physics/lineshapes/GSpline.cu
+++ b/src/PDFs/physics/lineshapes/GSpline.cu
@@ -101,12 +101,15 @@ __device__ resonance_function_ptr ptr_to_Spline = Spline_TDP;
 
 auto make_spline_curvatures(std::vector<Variable> vars, Lineshapes::spline_t SplineInfo) -> std::vector<fptype> {
     size_t size = std::get<2>(SplineInfo) - 2;
-    Eigen::Matrix<fptype, Eigen::Dynamic, Eigen::Dynamic> m(size, size);
+    // Eigen does not value-initialize dynamic matrices, so start from Zero(): the
+    // off-tridiagonal entries must be 0, otherwise the inverse is garbage.
+    Eigen::Matrix<fptype, Eigen::Dynamic, Eigen::Dynamic> m
+        = Eigen::Matrix<fptype, Eigen::Dynamic, Eigen::Dynamic>::Zero(size, size);
     for(size_t i = 0; i < size; i++) {
         m(i, i) = 4;
         if(i != size - 1) {
             m(i, i + 1) = 1;
-            m(i + 1, 1) = 1;
+            m(i + 1, i) = 1; // sub-diagonal: column i, not a hard-coded 1
         }
     }
     m = m.inverse();
@@ -115,8 +118,9 @@ auto make_spline_curvatures(std::vector<Variable> vars, Lineshapes::spline_t Spl
     for(unsigned int i = 0; i < size; ++i)
         L[i] = vars[i + 2].getValue() - 2 * vars[i + 1].getValue() + vars[i].getValue();
 
-    auto mtv       = m * L;
-    fptype spacing = (std::get<0>(SplineInfo) - std::get<1>(SplineInfo)) / std::get<2>(SplineInfo);
+    auto mtv = m * L;
+    // Knot spacing must match the device evaluator getSpline(): (s_max - s_min) / (nBins - 1).
+    fptype spacing = (std::get<1>(SplineInfo) - std::get<0>(SplineInfo)) / (std::get<2>(SplineInfo) - 1);
 
     std::vector<fptype> ret(vars.size(), 0);
     for(unsigned int i = 0; i < size; ++i) {


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

`make_spline_curvatures()` builds and inverts the tridiagonal system for the natural-cubic-spline second derivatives used by the `GSpline` lineshape. It had three defects:

1. **Uninitialized matrix.** `Eigen::Matrix<...> m(size, size)` is *not* value-initialized — Eigen leaves dynamic-matrix coefficients uninitialized. Only the diagonal and (some) off-diagonal entries were set, so the rest was garbage and the inverse was correct *only* when the heap happened to be zero-filled. Classic latent bug: passes on a fresh (zeroed) allocation, fails once the heap is dirty. Fixed with `::Zero(size, size)`.

2. **Wrong sub-diagonal index.** `m(i + 1, 1) = 1` hard-codes column `1` instead of `m(i + 1, i)`. The matrix is asymmetric and wrong for any spline with ≥ 5 knots (`size = nBins - 2 ≥ 3`).

3. **Knot-spacing mismatch.** Host used `(s_min - s_max) / nBins`; the device evaluator `getSpline()` uses `(s_max - s_min) / (nBins - 1)`. The curvatures were scaled by `((nBins-1)/nBins)^2` relative to the grid they're evaluated on (the sign is irrelevant since `spacing` is squared, but the factor is not).

The intended system is the standard symmetric tridiagonal `[1, 4, 1]` solve; the spacing now matches `getSpline()`.

## Verification

The natural-cubic-spline second-derivative system for equally spaced knots is, for each interior knot,

$$M_{i-1} + 4M_i + M_{i+1} = \frac{6}{h^2}\,(y_{i+1} - 2y_i + y_{i-1}),$$

i.e. a symmetric tridiagonal `[1,4,1]` matrix with RHS the second differences (`L[i]`), and curvatures `6·M/h²` (`ret`). The matrix construction and spacing now match this and the device-side `getSpline()` knot spacing.

## Testing

Builds cleanly (CPP backend). `GSpline` is reachable only through the Python bindings and has no C++ test or example, so there is no existing runtime regression to extend; the change restores the textbook construction the surrounding code already assumes.