### PR TITLE
fix uninitialised array in kMatrix

### DIFF
--- a/src/PDFs/physics/lineshapes/kMatrix.cu
+++ b/src/PDFs/physics/lineshapes/kMatrix.cu
@@ -84,6 +84,11 @@ __device__ auto kMatrixFunction(fptype Mpair, fptype m1, fptype m2, ParameterCon
     phaseSpace[4] = phsp_twoBody(s, mEta, mEtap);
 
     fpcomplex F[NCHANNELS][NCHANNELS];
+    for(unsigned int i = 0; i < NCHANNELS; ++i) {
+        for(unsigned int j = 0; j < NCHANNELS; ++j) {
+            F[i][j] = fpcomplex(0., 0.);
+        }
+    }
     getPropagator(kMatrix, phaseSpace, F, adlerTerm);
 
     // calculates output

--- a/src/PDFs/physics/resonances/kMatrix.cu
+++ b/src/PDFs/physics/resonances/kMatrix.cu
@@ -87,6 +87,11 @@ __device__ auto kMatrixRes(fptype m12, fptype m13, fptype m23, ParameterContaine
     phaseSpace[4] = phsp_twoBody(s, mEta, mEtap);
 
     fpcomplex F[NCHANNELS][NCHANNELS];
+    for(unsigned int i = 0; i < NCHANNELS; ++i) {
+        for(unsigned int j = 0; j < NCHANNELS; ++j) {
+            F[i][j] = fpcomplex(0., 0.);
+        }
+    }
     getPropagator(kMatrix, phaseSpace, F, adlerTerm);
 
     // calculates output


### PR DESCRIPTION
the `F[NCHANNELS][NCHANNELS]` is uninitialised, but expected to be initialised to zeroes. I ran into cases where the uninitialised entries evaluated to NaN, causing problems in the PDF evaluation